### PR TITLE
[update] review-pr 스킬을 PR 코멘트 반영 워크플로우로 교체

### DIFF
--- a/.claude/skills/review-pr/skill.md
+++ b/.claude/skills/review-pr/skill.md
@@ -20,7 +20,7 @@ For each comment, decide:
 ## Step 3 — Implement Changes
 
 Apply code changes for accepted comments.
-Run `./gradlew ktlintFormat` after edits.
+Run `npm run format` after edits.
 
 ## Step 4 — Commit & Push
 
@@ -40,13 +40,13 @@ git log --oneline -1
 
 For each **반영** comment:
 ```bash
-gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
+gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/<pr_number>/comments/<comment_id>/replies" \
   -f body="<short_hash> 에서 반영했습니다."
 ```
 
 For each **무시** comment:
 ```bash
-gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
+gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/<pr_number>/comments/<comment_id>/replies" \
   -f body="<이유> 때문에 반영하지 않았습니다."
 ```
 

--- a/.claude/skills/review-pr/skill.md
+++ b/.claude/skills/review-pr/skill.md
@@ -1,74 +1,66 @@
-# Skill: Reviewing Pull Requests
-
-## Overview
-A checklist-based guide for reviewing NestJS pull requests systematically.
-
+---
+name: review-pr
+description: Check PR review comments, reflect valid feedback into code, commit, push, then reply to each comment with the resolving commit hash.
 ---
 
-## How to Invoke
+## Step 1 — Collect PR Comments
 
-When asked to review a PR or a set of changed files, go through each checklist category below. For each item, check the actual code and flag any violations with the file path and line reference.
-
----
-
-## Review Checklist
-
-### 1. 기능 정확성 (Functional Correctness)
-- [ ] Does the implementation satisfy the stated requirements?
-- [ ] Are edge cases handled? (empty input, null, unauthorized access, etc.)
-- [ ] Are error responses returning the correct HTTP status codes?
-- [ ] Is async/await used correctly? (no unhandled promise rejections)
-
-### 2. NestJS 컨벤션 (NestJS Conventions)
-- [ ] Is layer responsibility correctly separated? (Controller → Service → Repository)
-- [ ] Is business logic kept out of controllers?
-- [ ] Are dependencies injected via constructor DI (no manual instantiation)?
-- [ ] Are DTOs used for request/response shapes?
-- [ ] Are decorators (`@Body()`, `@Param()`, `@Query()`) applied correctly?
-
-### 3. TypeORM
-- [ ] Are entities correctly defined with proper column types?
-- [ ] Is the Repository pattern used (no raw SQL unless justified)?
-- [ ] Are there N+1 query risks? (missing `relations` or `QueryBuilder` joins)
-- [ ] Are transactions used where multiple writes occur?
-- [ ] Are migrations created for schema changes?
-
-### 4. 보안 (Security)
-- [ ] Are authentication guards (`JwtAuthGuard`, etc.) applied to protected routes?
-- [ ] Is authorization checked? (does the user own the resource?)
-- [ ] Is all input validated via `class-validator` on DTOs?
-- [ ] Are sensitive fields (password, token) excluded from responses?
-- [ ] Are secrets read from environment variables, not hardcoded?
-
-### 5. 테스트 (Testing)
-- [ ] Are core business logic paths covered by unit tests?
-- [ ] Are edge cases and failure scenarios tested?
-- [ ] Are mocks/stubs used correctly (no real DB calls in unit tests)?
-- [ ] Do existing tests still pass with this change?
-
-### 6. 코드 품질 (Code Quality)
-- [ ] Is there dead code or commented-out code?
-- [ ] Is logic duplicated across files?
-- [ ] Is any single file or function doing too much? (single responsibility)
-- [ ] Are variable and function names clear and accurate?
-
----
-
-## Output Format
-
-Report only problems and improvement suggestions. Skip praise.
-
-```
-### 기능 정확성
-❌ `src/auth/auth.controller.ts:34` - refreshToken 엔드포인트에 JwtAuthGuard 누락
-   → `@UseGuards(JwtAuthGuard)` 데코레이터 추가 필요
-
-### TypeORM
-❌ `src/user/user.service.ts:61` - findAll()에서 N+1 위험
-   → relations 옵션 대신 QueryBuilder + leftJoinAndSelect 사용 권장
-
-### 테스트
-❌ 테스트 없음 - refreshToken 로직에 대한 단위 테스트가 존재하지 않음
+```bash
+gh pr view --json number -q .number
+gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/<pr_number>/comments" \
+  --jq '.[] | {id: .id, path: .path, line: .line, body: .body}'
 ```
 
-Use ✅ only when a category has zero issues (to confirm it was checked).
+## Step 2 — Evaluate Each Comment
+
+For each comment, decide:
+- **반영** — valid suggestion, implement it
+- **무시** — not applicable or disagree (explain why in reply)
+
+## Step 3 — Implement Changes
+
+Apply code changes for accepted comments.
+Run `./gradlew ktlintFormat` after edits.
+
+## Step 4 — Commit & Push
+
+Only after the user says to commit:
+```bash
+git add <files>
+git commit -m "update : 리뷰 반영 - <설명>"
+git push
+```
+
+Get the short commit hash:
+```bash
+git log --oneline -1
+```
+
+## Step 5 — Reply to Each Comment
+
+For each **반영** comment:
+```bash
+gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
+  -f body="<short_hash> 에서 반영했습니다."
+```
+
+For each **무시** comment:
+```bash
+gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
+  -f body="<이유> 때문에 반영하지 않았습니다."
+```
+
+## Step 6 — Report
+
+```
+## 반영한 코멘트
+- [file] "comment" → <hash> 에서 반영했습니다.
+
+## 반영하지 않은 코멘트
+- [file] "comment" → 사유: ...
+```
+
+## Important
+
+- Commit first, then post replies (replies must include the hash)
+- Never reply before committing


### PR DESCRIPTION
## 개요
코드 리뷰 체크리스트 방식의 review-pr 스킬을, PR에 달린 코멘트를 수집·평가·반영하고 커밋 해시로 답글을 다는 워크플로우로 교체

## 변경 내용
- [x] PR 코멘트 수집 → 반영/무시 판단 → 코드 수정 → 커밋&푸시 → 코멘트 답글 순서로 재구성
- [x] 커밋 후 각 코멘트에 `<hash> 에서 반영했습니다.` 답글 달도록 명시

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과