### PR TITLE
[fix] CD 파이프라인 Docker 이미지 태그 소문자 변환

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set lowercase image name
+        id: vars
+        run: echo "image=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -25,8 +29,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ steps.vars.outputs.image }}:latest
+            ghcr.io/${{ steps.vars.outputs.image }}:${{ github.sha }}
 
   deploy:
     needs: build-push


### PR DESCRIPTION
## 개요
`github.repository` 변수에 대문자가 포함되어 Docker 이미지 빌드가 실패하는 문제 수정

## 변경 내용
- [x] 이미지 태그 생성 전 소문자 변환 step 추가 (`tr '[:upper:]' '[:lower:]'`)
- [x] `github.repository` 대신 변환된 값을 이미지 태그에 사용

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과