### PR TITLE
[fix] CD 배포 스크립트 의존성 제거 및 SSH 인라인 실행으로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,6 +36,19 @@ jobs:
     needs: build-push
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Upload deploy script to app-1
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT_APP1 }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD_APP1 }}
+          source: scripts/deploy-app.sh
+          target: /opt/nochu/
+          mkdir: true
+
       - name: Deploy app-1
         uses: appleboy/ssh-action@v1
         with:
@@ -44,6 +57,17 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD_APP1 }}
           script: bash /opt/nochu/scripts/deploy-app.sh
+
+      - name: Upload deploy script to app-2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT_APP2 }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD_APP2 }}
+          source: scripts/deploy-app.sh
+          target: /opt/nochu/
+          mkdir: true
 
       - name: Deploy app-2
         uses: appleboy/ssh-action@v1


### PR DESCRIPTION
## 개요
서버에 deploy 스크립트 파일이 없거나 SCP 권한 문제로 배포가 실패하는 문제를 해결하기 위해 SSH 인라인 명령어 방식으로 변경

## 변경 내용
- [x] Docker 이미지 태그 소문자 변환 step 추가 (`github.repository` 대문자 문제 수정)
- [x] SCP로 deploy 스크립트 업로드하는 방식 제거
- [x] 배포 명령어를 SSH `script:` 블록에 인라인으로 직접 실행

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과