### PR TITLE
[fix] SCP 제거하고 SSH 인라인으로 배포 명령어 실행

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,19 +36,6 @@ jobs:
     needs: build-push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Upload deploy script to app-1
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          port: ${{ secrets.SSH_PORT_APP1 }}
-          username: ${{ secrets.SSH_USER }}
-          password: ${{ secrets.SSH_PASSWORD_APP1 }}
-          source: scripts/deploy-app.sh
-          target: /opt/nochu/
-          mkdir: true
-
       - name: Deploy app-1
         uses: appleboy/ssh-action@v1
         with:
@@ -56,18 +43,12 @@ jobs:
           port: ${{ secrets.SSH_PORT_APP1 }}
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD_APP1 }}
-          script: bash /opt/nochu/scripts/deploy-app.sh
-
-      - name: Upload deploy script to app-2
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          port: ${{ secrets.SSH_PORT_APP2 }}
-          username: ${{ secrets.SSH_USER }}
-          password: ${{ secrets.SSH_PASSWORD_APP2 }}
-          source: scripts/deploy-app.sh
-          target: /opt/nochu/
-          mkdir: true
+          script: |
+            IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
+            docker pull $IMAGE
+            docker compose -f /opt/nochu/docker-compose.app.yml up -d
+            CONTAINER=nochu-app
+            timeout 60 bash -c "until [ \"\$(docker inspect --format='{{.State.Health.Status}}' $CONTAINER)\" = \"healthy\" ]; do sleep 2; done"
 
       - name: Deploy app-2
         uses: appleboy/ssh-action@v1
@@ -76,4 +57,9 @@ jobs:
           port: ${{ secrets.SSH_PORT_APP2 }}
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD_APP2 }}
-          script: bash /opt/nochu/scripts/deploy-app.sh
+          script: |
+            IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
+            docker pull $IMAGE
+            docker compose -f /opt/nochu/docker-compose.app.yml up -d
+            CONTAINER=nochu-app
+            timeout 60 bash -c "until [ \"\$(docker inspect --format='{{.State.Health.Status}}' $CONTAINER)\" = \"healthy\" ]; do sleep 2; done"


### PR DESCRIPTION
## 개요
SCP 권한 문제로 배포가 실패하는 상황을 방지하기 위해 외부 스크립트 파일 의존성을 없애고 SSH 인라인 실행 방식으로 변경

## 변경 내용
- [x] `appleboy/scp-action` 제거
- [x] 배포 명령어(docker pull, compose up, healthcheck)를 SSH `script:` 블록에 직접 인라인

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과