### PR TITLE
[fix] SSH 세션 docker PATH 누락 문제 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,6 +44,8 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD_APP1 }}
           script: |
+            source ~/.profile || true
+            export PATH=$PATH:/usr/local/bin:/usr/bin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
             docker compose -f /opt/nochu/docker-compose.app.yml up -d
@@ -58,6 +60,8 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD_APP2 }}
           script: |
+            source ~/.profile || true
+            export PATH=$PATH:/usr/local/bin:/usr/bin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
             docker compose -f /opt/nochu/docker-compose.app.yml up -d


### PR DESCRIPTION
## 개요
비인터랙티브 SSH 세션에서 PATH에 docker가 없어 배포가 실패하는 문제 수정

## 변경 내용
- [x] 배포 스크립트 실행 전 `source ~/.profile` 및 `/usr/local/bin`, `/usr/bin` PATH 명시적 추가

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과