### PR TITLE
[fix] SSH 배포 PATH에 snap/bin 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,8 +44,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD_APP1 }}
           script: |
-            source ~/.profile || true
-            export PATH=$PATH:/usr/local/bin:/usr/bin
+            export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
             docker compose -f /opt/nochu/docker-compose.app.yml up -d
@@ -60,8 +59,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           password: ${{ secrets.SSH_PASSWORD_APP2 }}
           script: |
-            source ~/.profile || true
-            export PATH=$PATH:/usr/local/bin:/usr/bin
+            export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
             docker compose -f /opt/nochu/docker-compose.app.yml up -d


### PR DESCRIPTION
## 개요
snap으로 설치된 docker가 비인터랙티브 SSH 세션에서 인식되지 않는 문제 해결을 위해 PATH를 전체 경로로 재설정

## 변경 내용
- [x] `/snap/bin`을 포함한 전체 시스템 PATH로 명시적 재설정

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과