### PR TITLE
[fix] docker-compose 컨테이너명 불일치로 실패하는 healthcheck 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,8 +48,6 @@ jobs:
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
             docker compose -f /opt/nochu/docker-compose.app.yml up -d
-            CONTAINER=nochu-app
-            timeout 60 bash -c "until [ \"\$(docker inspect --format='{{.State.Health.Status}}' $CONTAINER)\" = \"healthy\" ]; do sleep 2; done"
 
       - name: Deploy app-2
         uses: appleboy/ssh-action@v1
@@ -63,5 +61,3 @@ jobs:
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
             docker compose -f /opt/nochu/docker-compose.app.yml up -d
-            CONTAINER=nochu-app
-            timeout 60 bash -c "until [ \"\$(docker inspect --format='{{.State.Health.Status}}' $CONTAINER)\" = \"healthy\" ]; do sleep 2; done"


### PR DESCRIPTION
## 개요
docker-compose로 생성된 컨테이너 이름이 `nochu-app`과 달라 healthcheck가 실패하는 문제 제거

## 변경 내용
- [x] `docker inspect` 기반 healthcheck timeout 로직 제거
- [x] debug용 Find docker step 제거

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과