### PR TITLE
[fix] GHCR 로그인 추가 및 docker-compose V1 명령어로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,9 +45,10 @@ jobs:
           password: ${{ secrets.SSH_PASSWORD_APP1 }}
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
-            docker compose -f /opt/nochu/docker-compose.app.yml up -d
+            docker-compose -f /opt/nochu/docker-compose.app.yml up -d
 
       - name: Deploy app-2
         uses: appleboy/ssh-action@v1
@@ -58,6 +59,7 @@ jobs:
           password: ${{ secrets.SSH_PASSWORD_APP2 }}
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
-            docker compose -f /opt/nochu/docker-compose.app.yml up -d
+            docker-compose -f /opt/nochu/docker-compose.app.yml up -d


### PR DESCRIPTION
## 개요
서버에서 GHCR 미인증으로 이미지 pull이 실패하고, docker compose V1 명령어 인식 불가로 배포가 실패하는 문제 수정

## 변경 내용
- [x] `docker login ghcr.io` 추가 (`GHCR_TOKEN`, `GHCR_USER` secret 사용)
- [x] `docker compose -f` → `docker-compose -f` (V1 호환)

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과