### PR TITLE
[fix] 배포 시 서버에 docker-compose.app.yml 생성

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,10 +45,21 @@ jobs:
           password: ${{ secrets.SSH_PASSWORD_APP1 }}
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+            mkdir -p /opt/nochu
+            cat > /opt/nochu/docker-compose.app.yml << 'COMPOSE'
+            services:
+              app:
+                image: ghcr.io/team-hanseungil/nochu-be-nestjs:latest
+                container_name: nochu-app
+                ports:
+                  - "3000:3000"
+                env_file: .env
+                restart: unless-stopped
+            COMPOSE
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
-            docker-compose -f /opt/nochu/docker-compose.app.yml up -d
+            cd /opt/nochu && docker-compose -f docker-compose.app.yml up -d
 
       - name: Deploy app-2
         uses: appleboy/ssh-action@v1
@@ -59,7 +70,18 @@ jobs:
           password: ${{ secrets.SSH_PASSWORD_APP2 }}
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+            mkdir -p /opt/nochu
+            cat > /opt/nochu/docker-compose.app.yml << 'COMPOSE'
+            services:
+              app:
+                image: ghcr.io/team-hanseungil/nochu-be-nestjs:latest
+                container_name: nochu-app
+                ports:
+                  - "3000:3000"
+                env_file: .env
+                restart: unless-stopped
+            COMPOSE
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
-            docker-compose -f /opt/nochu/docker-compose.app.yml up -d
+            cd /opt/nochu && docker-compose -f docker-compose.app.yml up -d


### PR DESCRIPTION
## 개요
서버에 docker-compose.app.yml이 없어 배포가 실패하는 문제 해결 — SSH 스크립트에서 파일을 직접 생성

## 변경 내용
- [x] 배포 전 `/opt/nochu/` 디렉토리 생성
- [x] `docker-compose.app.yml` 내용을 SSH 스크립트에서 heredoc으로 서버에 기록
- [x] `cd /opt/nochu` 후 docker-compose 실행

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과