### PR TITLE
[fix] 배포 경로 홈 디렉토리로 변경 및 nginx IP 환경변수화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,21 +45,21 @@ jobs:
           password: ${{ secrets.SSH_PASSWORD_APP1 }}
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
-            mkdir -p /opt/nochu
-            cat > /opt/nochu/docker-compose.app.yml << 'COMPOSE'
-            services:
-              app:
-                image: ghcr.io/team-hanseungil/nochu-be-nestjs:latest
-                container_name: nochu-app
-                ports:
-                  - "3000:3000"
-                env_file: .env
-                restart: unless-stopped
-            COMPOSE
+            mkdir -p ~/nochu
+            cat > ~/nochu/docker-compose.app.yml << 'COMPOSE'
+services:
+  app:
+    image: ghcr.io/team-hanseungil/nochu-be-nestjs:latest
+    container_name: nochu-app
+    ports:
+      - "3000:3000"
+    env_file: /home/$USER/nochu/.env
+    restart: unless-stopped
+COMPOSE
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
-            cd /opt/nochu && docker-compose -f docker-compose.app.yml up -d
+            cd ~/nochu && docker-compose -f docker-compose.app.yml up -d
 
       - name: Deploy app-2
         uses: appleboy/ssh-action@v1
@@ -70,18 +70,18 @@ jobs:
           password: ${{ secrets.SSH_PASSWORD_APP2 }}
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
-            mkdir -p /opt/nochu
-            cat > /opt/nochu/docker-compose.app.yml << 'COMPOSE'
-            services:
-              app:
-                image: ghcr.io/team-hanseungil/nochu-be-nestjs:latest
-                container_name: nochu-app
-                ports:
-                  - "3000:3000"
-                env_file: .env
-                restart: unless-stopped
-            COMPOSE
+            mkdir -p ~/nochu
+            cat > ~/nochu/docker-compose.app.yml << 'COMPOSE'
+services:
+  app:
+    image: ghcr.io/team-hanseungil/nochu-be-nestjs:latest
+    container_name: nochu-app
+    ports:
+      - "3000:3000"
+    env_file: /home/$USER/nochu/.env
+    restart: unless-stopped
+COMPOSE
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
-            cd /opt/nochu && docker-compose -f docker-compose.app.yml up -d
+            cd ~/nochu && docker-compose -f docker-compose.app.yml up -d

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,6 @@
 upstream nestjs_backend {
-  server <VM2_IP>:3000;
-  server <VM3_IP>:3000;
+  server ${APP1_IP}:3000;
+  server ${APP2_IP}:3000;
 }
 
 server {


### PR DESCRIPTION
## 개요
SSH 유저의 `/opt/nochu` 쓰기 권한 문제를 홈 디렉토리 사용으로 해결하고, nginx 설정의 하드코딩된 IP를 환경변수 플레이스홀더로 교체

## 변경 내용
- [x] CD 배포 경로 `/opt/nochu` → `~/nochu` 로 변경
- [x] nginx upstream IP `APP1_IP`, `APP2_IP` 환경변수 플레이스홀더로 변경 (`envsubst` 사용)

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과