### PR TITLE
[fix] replace heredoc with echo group to fix YAML syntax error in cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,16 +46,16 @@ jobs:
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             mkdir -p ~/nochu
-            cat > ~/nochu/docker-compose.app.yml << 'COMPOSE'
-services:
-  app:
-    image: ghcr.io/team-hanseungil/nochu-be-nestjs:latest
-    container_name: nochu-app
-    ports:
-      - "3000:3000"
-    env_file: /home/$USER/nochu/.env
-    restart: unless-stopped
-COMPOSE
+            {
+              echo 'services:'
+              echo '  app:'
+              echo '    image: ghcr.io/team-hanseungil/nochu-be-nestjs:latest'
+              echo '    container_name: nochu-app'
+              echo '    ports:'
+              echo '      - "3000:3000"'
+              echo "    env_file: /home/$USER/nochu/.env"
+              echo '    restart: unless-stopped'
+            } > ~/nochu/docker-compose.app.yml
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
@@ -71,16 +71,16 @@ COMPOSE
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             mkdir -p ~/nochu
-            cat > ~/nochu/docker-compose.app.yml << 'COMPOSE'
-services:
-  app:
-    image: ghcr.io/team-hanseungil/nochu-be-nestjs:latest
-    container_name: nochu-app
-    ports:
-      - "3000:3000"
-    env_file: /home/$USER/nochu/.env
-    restart: unless-stopped
-COMPOSE
+            {
+              echo 'services:'
+              echo '  app:'
+              echo '    image: ghcr.io/team-hanseungil/nochu-be-nestjs:latest'
+              echo '    container_name: nochu-app'
+              echo '    ports:'
+              echo '      - "3000:3000"'
+              echo "    env_file: /home/$USER/nochu/.env"
+              echo '    restart: unless-stopped'
+            } > ~/nochu/docker-compose.app.yml
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE


### PR DESCRIPTION
## 개요
YAML block scalar 내 heredoc 종료자가 column 0에 위치해 YAML 파서 오류가 발생하는 문제 수정

## 변경 내용
- [x] heredoc(`<< 'COMPOSE'`)을 echo 그룹(`{ echo ... } > file`)으로 교체하여 YAML 문법 오류 해결
- [x] app-1, app-2 배포 스크립트 동일하게 적용