### PR TITLE
[fix] write .env from APP_ENV secret on deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,6 +46,7 @@ jobs:
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             mkdir -p ~/nochu
+            echo "${{ secrets.APP_ENV }}" > ~/nochu/.env
             {
               echo 'services:'
               echo '  app:'
@@ -71,6 +72,7 @@ jobs:
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             mkdir -p ~/nochu
+            echo "${{ secrets.APP_ENV }}" > ~/nochu/.env
             {
               echo 'services:'
               echo '  app:'


### PR DESCRIPTION
## 개요
배포 시 VM에 .env 파일이 없어 컨테이너 실행 실패하는 문제 수정

## 변경 내용
- [x] 배포 스크립트에서 APP_ENV 시크릿으로 ~/nochu/.env 자동 생성
- [x] app-1, app-2 동일하게 적용

## 테스트
- [ ] 단위 테스트 추가/수정
- [ ] e2e 테스트 통과