### PR TITLE
CD 배포 시 docker-compose 컨테이너 재생성 오류 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,7 @@ jobs:
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
+            docker ps -aq --filter name=nochu-app | xargs -r docker rm -f
             cd ~/nochu && docker-compose -f docker-compose.app.yml up -d
 
       - name: Deploy app-2
@@ -86,4 +87,5 @@ jobs:
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
             IMAGE=ghcr.io/team-hanseungil/nochu-be-nestjs:latest
             docker pull $IMAGE
+            docker ps -aq --filter name=nochu-app | xargs -r docker rm -f
             cd ~/nochu && docker-compose -f docker-compose.app.yml up -d


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- CD 배포 단계에서 기존 nochu-app 컨테이너를 먼저 강제 제거하도록 수정
- docker-compose v1이 기존 컨테이너를 재생성할 때 발생하던 `KeyError: ContainerConfig` 오류 회피
- 신규 배포(기존 컨테이너 없음)에서는 xargs -r로 아무 동작도 하지 않아 안전

## 💬리뷰 요구사항(선택)

> 서버의 docker-compose가 v1(1.29.2)이라 발생한 문제. 근본 해결은 compose v2 전환이지만, app2엔 v2가 없어 우선 v1 호환 방식(기존 컨테이너 제거)으로 처리했습니다