### PR TITLE
CD SSH 인증을 비밀번호에서 배포 키 방식으로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           port: ${{ secrets.SSH_PORT_APP1 }}
           username: ${{ secrets.SSH_USER }}
-          password: ${{ secrets.SSH_PASSWORD_APP1 }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             mkdir -p ~/nochu
@@ -69,7 +69,7 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           port: ${{ secrets.SSH_PORT_APP2 }}
           username: ${{ secrets.SSH_USER }}
-          password: ${{ secrets.SSH_PASSWORD_APP2 }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             mkdir -p ~/nochu


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- CD 배포 SSH 인증을 비밀번호(SSH_PASSWORD_APP1/APP2)에서 전용 배포 키(SSH_PRIVATE_KEY)로 전환
- app1/app2에 ed25519 공개키를 authorized_keys로 등록하고 개인키 로그인 검증 완료
- 개인키는 SSH_PRIVATE_KEY 시크릿으로 저장

## 💬리뷰 요구사항(선택)

> 비밀번호 인증은 서버에 아직 살아있어 롤백 가능합니다. 키 방식 안정화가 확인되면 SSH_PASSWORD_APP1/APP2 시크릿 삭제 및 서버 PasswordAuthentication 비활성화를 별도로 진행하는 게 좋습니다