### PR TITLE
Swagger API 문서 셋업 및 하네스 문서 영어화

### DIFF
--- a/.claude/rules/swagger-conventions.md
+++ b/.claude/rules/swagger-conventions.md
@@ -1,0 +1,49 @@
+# Swagger / API Docs Conventions
+
+## Setup
+
+- Package: `@nestjs/swagger`
+- Docs UI: `GET /docs` (registered in `main.ts` via `SwaggerModule.setup('docs', ...)`)
+- Auto DTO docs: register `@nestjs/swagger` under `compilerOptions.plugins` in `nest-cli.json`. The plugin infers `@ApiProperty` from the TS types, so do not add `@ApiProperty` by hand for plain fields.
+
+## main.ts
+
+```typescript
+const config = new DocumentBuilder()
+  .setTitle('nochu API')
+  .setDescription('Emotion-based music recommendation service API')
+  .setVersion('1.0')
+  .addBearerAuth()
+  .build();
+const document = SwaggerModule.createDocument(app, config);
+SwaggerModule.setup('docs', app, document);
+```
+
+## Controller Rules
+
+- Every controller gets `@ApiTags('<feature>')` (kebab/lowercase, matching the resource name).
+- Every route gets `@ApiOperation({ summary: '<concise action summary>' })`.
+- JWT-protected routes (or controllers) get `@ApiBearerAuth()`. If the whole controller is guarded, declare it once at the class level.
+
+```typescript
+@ApiTags('preferences')
+@ApiBearerAuth()
+@Controller('preferences')
+@UseGuards(JwtAuthGuard)
+export class PreferencesController {
+  @Post()
+  @ApiOperation({ summary: 'Submit onboarding preferences' })
+  upsert() {}
+}
+```
+
+## DTO Rules
+
+- The plugin infers the schema from types and `class-validator` decorators, so plain fields do not need `@ApiProperty`.
+- Add `@ApiProperty({ example, description })` only when an example or description is genuinely needed.
+- Return a ResDto type so the response schema is captured. Use `@ApiOkResponse({ type: XxxResDto })` when needed.
+
+## Rules of Thumb
+
+- `@ApiTags` + `@ApiOperation` are required whenever a new endpoint is added.
+- The docs path (`/docs`) is reachable without authentication (manage production exposure at the infrastructure layer).

--- a/.claude/skills/plan-deep-dive/skill.md
+++ b/.claude/skills/plan-deep-dive/skill.md
@@ -16,20 +16,20 @@ A structured analysis process to run before implementing complex features. Preve
 
 ## Step-by-Step Process
 
-### Step 1: 요구사항 파악 (Clarify Requirements)
+### Step 1: Clarify Requirements
 Answer exactly: what needs to be built?
 - What are the inputs and outputs?
 - What are the acceptance criteria?
 - What is explicitly out of scope?
 
-### Step 2: 영향 범위 분석 (Impact Analysis)
+### Step 2: Impact Analysis
 List every file and module that will change:
 - Which controllers, services, repositories are affected?
 - Are new entities or columns needed?
 - Does this require a new module or changes to `AppModule`?
 - Are there shared utilities or interceptors that need updates?
 
-### Step 3: 데이터 흐름 추적 (Trace Data Flow)
+### Step 3: Trace Data Flow
 Follow the request lifecycle end to end:
 ```
 HTTP Request → Controller → Guard → Service → Repository → DB
@@ -38,14 +38,14 @@ HTTP Request → Controller → Guard → Service → Repository → DB
 ```
 Identify exactly where the new logic sits in this chain.
 
-### Step 4: 엣지 케이스 목록 (Edge Cases)
+### Step 4: Edge Cases
 List failure scenarios and boundary conditions:
 - What happens if the resource does not exist?
 - What if the user is not authorized?
 - What if an external service is down?
 - What are the boundary values for numeric/date inputs?
 
-### Step 5: 구현 순서 결정 (Implementation Order)
+### Step 5: Implementation Order
 Order tasks bottom-up by dependency:
 1. DB schema / entity changes first
 2. Repository layer
@@ -54,8 +54,8 @@ Order tasks bottom-up by dependency:
 5. Guards / interceptors
 6. Tests
 
-### Step 6: 체크리스트 작성 (Task Breakdown)
-Break down into atomic tasks using TodoWrite. Each task should be completable independently and verifiable.
+### Step 6: Task Breakdown
+Break down into atomic tasks using TaskCreate. Each task should be completable independently and verifiable. Mark each task in_progress when starting, completed when done using TaskUpdate.
 
 ---
 

--- a/.claude/skills/review-pr/skill.md
+++ b/.claude/skills/review-pr/skill.md
@@ -14,8 +14,8 @@ gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/<pr_n
 ## Step 2 — Evaluate Each Comment
 
 For each comment, decide:
-- **반영** — valid suggestion, implement it
-- **무시** — not applicable or disagree (explain why in reply)
+- **반영 (accept)** — valid suggestion, implement it
+- **무시 (ignore)** — not applicable or disagree (explain why in reply)
 
 ## Step 3 — Implement Changes
 
@@ -27,7 +27,7 @@ Run `npm run format` after edits.
 Only after the user says to commit:
 ```bash
 git add <files>
-git commit -m "update : 리뷰 반영 - <설명>"
+git commit -m "update: 리뷰 반영 - <설명>"
 git push
 ```
 
@@ -38,13 +38,13 @@ git log --oneline -1
 
 ## Step 5 — Reply to Each Comment
 
-For each **반영** comment:
+For each **반영 (accept)** comment:
 ```bash
 gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/<pr_number>/comments/<comment_id>/replies" \
   -f body="<short_hash> 에서 반영했습니다."
 ```
 
-For each **무시** comment:
+For each **무시 (ignore)** comment:
 ```bash
 gh api "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/pulls/<pr_number>/comments/<comment_id>/replies" \
   -f body="<이유> 때문에 반영하지 않았습니다."

--- a/.claude/skills/systematic-debugging/skill.md
+++ b/.claude/skills/systematic-debugging/skill.md
@@ -16,7 +16,7 @@ A structured debugging workflow that finds root causes instead of guessing.
 
 ## Step-by-Step Process
 
-### Step 1: 증상 기록 (Record the Symptom)
+### Step 1: Record the Symptom
 Capture exactly what is happening:
 - Full error message
 - Stack trace (top frame is usually most relevant)
@@ -24,13 +24,13 @@ Capture exactly what is happening:
 - Which environment: local / staging / production?
 - Is it reproducible every time or intermittent?
 
-### Step 2: 재현 (Reproduce)
+### Step 2: Reproduce
 Create the smallest possible reproduction:
 - Isolate the failing request or function call
 - Strip out unrelated context
 - Write a failing test if possible — this also serves as the fix verification
 
-### Step 3: 가설 수립 (Form Hypotheses)
+### Step 3: Form Hypotheses
 List 2–3 candidate causes ranked by likelihood:
 ```
 1. [Most likely] JWT secret mismatch between issuer and verifier
@@ -39,25 +39,25 @@ List 2–3 candidate causes ranked by likelihood:
 ```
 Do not fix anything yet.
 
-### Step 4: 검증 (Validate Each Hypothesis)
+### Step 4: Validate Each Hypothesis
 For each hypothesis, find evidence before changing code:
 - Add temporary log statements
 - Inspect values in a debugger or via unit test
 - Read the relevant code path carefully
 - Eliminate hypotheses one by one
 
-### Step 5: 근본 원인 특정 (Identify Root Cause)
+### Step 5: Identify Root Cause
 Find the deepest layer where the problem originates. Symptoms often appear far from the cause:
 - A 500 error in the controller may originate in a misconfigured TypeORM entity
 - A 401 may come from a missing provider in the module, not the guard logic itself
 
-### Step 6: 수정 (Fix with Minimal Change)
+### Step 6: Fix with Minimal Change
 Apply the smallest change that resolves the root cause:
 - Do not refactor while fixing
 - Do not fix unrelated issues discovered during investigation
 - If the fix is non-obvious, add a comment explaining why
 
-### Step 7: 검증 (Verify the Fix)
+### Step 7: Verify the Fix
 - Re-run the failing test — it must now pass
 - Run the full test suite to check for regressions
 - Manually verify the original symptom is gone

--- a/.claude/skills/write-pr/skill.md
+++ b/.claude/skills/write-pr/skill.md
@@ -51,8 +51,8 @@ Current template structure:
 ## Writing Rules
 
 - Focus on **intent**, not mechanics. Explain *why* the code changed, not *that* it changed.
-- Bad: "AuthService에 메서드 추가함"
-- Good: "액세스 토큰 만료 시 자동 갱신되지 않는 문제를 해결하기 위해 refreshToken 로직 추가"
+- Bad: "Added a method to AuthService"
+- Good: "Added refreshToken logic to fix the access token not auto-refreshing on expiry"
 - Keep the work summary concise; bullet by behavior, not file names.
 - If there is no related issue, write `없음` under `#️⃣연관된 이슈`.
 

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "plugins": ["@nestjs/swagger"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.4.4",
         "@nestjs/typeorm": "^11.0.1",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
@@ -1926,6 +1927,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
@@ -2394,6 +2401,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
@@ -2521,6 +2548,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.4.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.4.tgz",
+      "integrity": "sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.6"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2663,6 +2723,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
@@ -4582,7 +4649,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -8507,7 +8573,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11079,6 +11144,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
+      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.4.4",
     "@nestjs/typeorm": "^11.0.1",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -9,7 +9,12 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { Request } from 'express';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtPayload } from './strategies/jwt.strategy';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
@@ -24,6 +29,7 @@ export class AuthController {
 
   @Post('spotify')
   @ApiOperation({ summary: 'Spotify 인가 코드로 로그인/회원가입' })
+  @ApiOkResponse({ type: TokenResDto })
   @HttpCode(HttpStatus.OK)
   spotifyLogin(@Body() dto: SpotifyLoginReqDto): Promise<TokenResDto> {
     return this.authService.loginWithCode(dto.code);
@@ -31,6 +37,7 @@ export class AuthController {
 
   @Post('refresh')
   @ApiOperation({ summary: '리프레시 토큰으로 액세스 토큰 재발급' })
+  @ApiOkResponse({ type: TokenResDto })
   @HttpCode(HttpStatus.OK)
   refresh(@Body() dto: RefreshTokenReqDto): Promise<TokenResDto> {
     return this.authService.refresh(dto.refreshToken);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { Request } from 'express';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtPayload } from './strategies/jwt.strategy';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
@@ -16,23 +17,28 @@ import { SpotifyLoginReqDto } from './dto/spotify-login.req.dto';
 import { RefreshTokenReqDto } from './dto/refresh-token.req.dto';
 import { TokenResDto } from './dto/token.res.dto';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('spotify')
+  @ApiOperation({ summary: 'Spotify 인가 코드로 로그인/회원가입' })
   @HttpCode(HttpStatus.OK)
   spotifyLogin(@Body() dto: SpotifyLoginReqDto): Promise<TokenResDto> {
     return this.authService.loginWithCode(dto.code);
   }
 
   @Post('refresh')
+  @ApiOperation({ summary: '리프레시 토큰으로 액세스 토큰 재발급' })
   @HttpCode(HttpStatus.OK)
   refresh(@Body() dto: RefreshTokenReqDto): Promise<TokenResDto> {
     return this.authService.refresh(dto.refreshToken);
   }
 
   @Delete('logout')
+  @ApiOperation({ summary: '로그아웃 (리프레시 토큰 무효화)' })
+  @ApiBearerAuth()
   @HttpCode(HttpStatus.NO_CONTENT)
   @UseGuards(JwtAuthGuard)
   logout(@Req() req: Request): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,11 @@ async function bootstrap() {
     .addBearerAuth()
     .build();
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('docs', app, document);
+  SwaggerModule.setup('docs', app, document, {
+    swaggerOptions: {
+      persistAuthorization: true,
+    },
+  });
 
   await app.listen(process.env.PORT ?? 3000);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
@@ -15,6 +16,15 @@ async function bootstrap() {
   );
 
   app.useGlobalFilters(new HttpExceptionFilter());
+
+  const config = new DocumentBuilder()
+    .setTitle('nochu API')
+    .setDescription('감정 기반 음악 추천 서비스 API')
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('docs', app, document);
 
   await app.listen(process.env.PORT ?? 3000);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- @nestjs/swagger 도입, /docs 경로에 Swagger UI 노출 (DocumentBuilder + addBearerAuth)
- nest-cli.json에 swagger 플러그인 등록해 DTO 스키마 자동 문서화
- auth 컨트롤러에 @ApiTags/@ApiOperation/@ApiBearerAuth 적용
- Swagger 컨벤션 룰 문서 추가 (.claude/rules/swagger-conventions.md)
- .claude 룰/스킬 문서의 한국어 설명을 영어로 정리 (커밋·PR 메시지 언어 컨벤션은 한국어 유지)

## 💬리뷰 요구사항(선택)

> 앱을 띄워 /docs-json에서 auth 라우트 + bearerAuth 스킴 생성을 확인했습니다. preferences 엔드포인트는 이 브랜치에 없어(별도 머지됨) @ApiTags/@ApiOperation 미적용 상태 → 후속으로 추가 예정. CLAUDE.md는 워킹트리 상태가 꼬여 이번 커밋에서 제외했습니다