### PR TITLE
로그인 응답 온보딩 플래그 추가 및 회원가입/로그인 e2e 테스트

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,7 +28,11 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn'
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
     },
   },
   {

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -4,6 +4,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { RedisModule } from '../redis/redis.module';
 import { UsersModule } from '../users/users.module';
+import { PreferencesModule } from '../preferences/preferences.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
@@ -21,6 +22,7 @@ import { JwtStrategy } from './strategies/jwt.strategy';
     }),
     UsersModule,
     RedisModule,
+    PreferencesModule,
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy],

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,173 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import * as bcrypt from 'bcrypt';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { RedisService } from '../redis/redis.service';
+import { PreferencesService } from '../preferences/preferences.service';
+import { UnauthorizedException } from '../common/exceptions/unauthorized.exception';
+
+function jsonResponse(ok: boolean, body: unknown): Response {
+  return { ok, json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+const CONFIG: Record<string, string> = {
+  JWT_REFRESH_SECRET: 'refresh-secret',
+  SPOTIFY_CLIENT_ID: 'client-id',
+  SPOTIFY_CLIENT_SECRET: 'client-secret',
+  SPOTIFY_CALLBACK_URL: 'nochu://auth/spotify/callback',
+};
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let jwt: { sign: jest.Mock; verify: jest.Mock };
+  let usersService: { findBySpotifyId: jest.Mock; create: jest.Mock };
+  let redisService: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
+  let preferencesService: { findByUserId: jest.Mock };
+  let configService: { get: jest.Mock };
+  let fetchMock: jest.SpyInstance;
+
+  const user = { id: 'user-1', email: 'a@b.com', spotifyId: 'sp-1' };
+
+  function mockSpotifySuccess() {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(true, { access_token: 'sp-access' }))
+      .mockResolvedValueOnce(
+        jsonResponse(true, {
+          id: 'sp-1',
+          display_name: 'Name',
+          email: 'a@b.com',
+          images: [{ url: 'http://img' }],
+        }),
+      );
+  }
+
+  beforeEach(async () => {
+    jwt = { sign: jest.fn().mockReturnValue('token'), verify: jest.fn() };
+    usersService = { findBySpotifyId: jest.fn(), create: jest.fn() };
+    redisService = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
+    preferencesService = { findByUserId: jest.fn() };
+    configService = { get: jest.fn((key: string) => CONFIG[key]) };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: JwtService, useValue: jwt },
+        { provide: ConfigService, useValue: configService },
+        { provide: UsersService, useValue: usersService },
+        { provide: RedisService, useValue: redisService },
+        { provide: PreferencesService, useValue: preferencesService },
+      ],
+    }).compile();
+
+    service = moduleRef.get(AuthService);
+    fetchMock = jest.spyOn(global, 'fetch');
+    jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed' as never);
+    jest.spyOn(bcrypt, 'compare').mockResolvedValue(true as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('loginWithCode', () => {
+    it('creates a new user and returns onboarded=false', async () => {
+      mockSpotifySuccess();
+      usersService.findBySpotifyId.mockResolvedValue(null);
+      usersService.create.mockResolvedValue(user);
+      preferencesService.findByUserId.mockResolvedValue(null);
+
+      const res = await service.loginWithCode('code');
+
+      expect(usersService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ spotifyId: 'sp-1', email: 'a@b.com' }),
+      );
+      expect(redisService.set).toHaveBeenCalledWith(
+        'refresh:user-1',
+        'hashed',
+        expect.any(Number),
+      );
+      expect(res.accessToken).toBe('token');
+      expect(res.onboarded).toBe(false);
+    });
+
+    it('reuses an existing user and returns onboarded=true', async () => {
+      mockSpotifySuccess();
+      usersService.findBySpotifyId.mockResolvedValue(user);
+      preferencesService.findByUserId.mockResolvedValue({ id: 'pref-1' });
+
+      const res = await service.loginWithCode('code');
+
+      expect(usersService.create).not.toHaveBeenCalled();
+      expect(res.onboarded).toBe(true);
+    });
+
+    it('throws when Spotify code exchange fails', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(false, {}));
+      await expect(service.loginWithCode('bad')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws when Spotify profile fetch fails', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse(true, { access_token: 'x' }))
+        .mockResolvedValueOnce(jsonResponse(false, {}));
+      await expect(service.loginWithCode('code')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws when Spotify config is missing', async () => {
+      configService.get.mockReturnValue(undefined);
+      await expect(service.loginWithCode('code')).rejects.toThrow();
+    });
+  });
+
+  describe('refresh', () => {
+    it('issues new tokens for a valid refresh token', async () => {
+      jwt.verify.mockReturnValue({ sub: 'user-1', email: 'a@b.com' });
+      redisService.get.mockResolvedValue('hashed');
+      preferencesService.findByUserId.mockResolvedValue(null);
+
+      const res = await service.refresh('valid-token');
+
+      expect(res.accessToken).toBe('token');
+      expect(res.onboarded).toBe(false);
+    });
+
+    it('throws when the token cannot be verified', async () => {
+      jwt.verify.mockImplementation(() => {
+        throw new Error('invalid');
+      });
+      await expect(service.refresh('x')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws when no token is stored', async () => {
+      jwt.verify.mockReturnValue({ sub: 'user-1', email: null });
+      redisService.get.mockResolvedValue(null);
+      await expect(service.refresh('x')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws when the stored hash does not match', async () => {
+      jwt.verify.mockReturnValue({ sub: 'user-1', email: null });
+      redisService.get.mockResolvedValue('hashed');
+      jest.spyOn(bcrypt, 'compare').mockResolvedValue(false as never);
+      await expect(service.refresh('x')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('deletes the stored refresh token', async () => {
+      await service.logout('user-1');
+      expect(redisService.del).toHaveBeenCalledWith('refresh:user-1');
+    });
+  });
+});

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -24,7 +24,7 @@ describe('AuthService', () => {
   let jwt: { sign: jest.Mock; verify: jest.Mock };
   let usersService: { findBySpotifyId: jest.Mock; create: jest.Mock };
   let redisService: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
-  let preferencesService: { findByUserId: jest.Mock };
+  let preferencesService: { existsByUserId: jest.Mock };
   let configService: { get: jest.Mock };
   let fetchMock: jest.SpyInstance;
 
@@ -47,7 +47,7 @@ describe('AuthService', () => {
     jwt = { sign: jest.fn().mockReturnValue('token'), verify: jest.fn() };
     usersService = { findBySpotifyId: jest.fn(), create: jest.fn() };
     redisService = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
-    preferencesService = { findByUserId: jest.fn() };
+    preferencesService = { existsByUserId: jest.fn() };
     configService = { get: jest.fn((key: string) => CONFIG[key]) };
 
     const moduleRef: TestingModule = await Test.createTestingModule({
@@ -76,7 +76,7 @@ describe('AuthService', () => {
       mockSpotifySuccess();
       usersService.findBySpotifyId.mockResolvedValue(null);
       usersService.create.mockResolvedValue(user);
-      preferencesService.findByUserId.mockResolvedValue(null);
+      preferencesService.existsByUserId.mockResolvedValue(false);
 
       const res = await service.loginWithCode('code');
 
@@ -95,7 +95,7 @@ describe('AuthService', () => {
     it('reuses an existing user and returns onboarded=true', async () => {
       mockSpotifySuccess();
       usersService.findBySpotifyId.mockResolvedValue(user);
-      preferencesService.findByUserId.mockResolvedValue({ id: 'pref-1' });
+      preferencesService.existsByUserId.mockResolvedValue(true);
 
       const res = await service.loginWithCode('code');
 
@@ -129,7 +129,7 @@ describe('AuthService', () => {
     it('issues new tokens for a valid refresh token', async () => {
       jwt.verify.mockReturnValue({ sub: 'user-1', email: 'a@b.com' });
       redisService.get.mockResolvedValue('hashed');
-      preferencesService.findByUserId.mockResolvedValue(null);
+      preferencesService.existsByUserId.mockResolvedValue(false);
 
       const res = await service.refresh('valid-token');
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -5,6 +5,7 @@ import * as bcrypt from 'bcrypt';
 import { UnauthorizedException } from '../common/exceptions/unauthorized.exception';
 import { RedisService } from '../redis/redis.service';
 import { UsersService } from '../users/users.service';
+import { PreferencesService } from '../preferences/preferences.service';
 import { JwtPayload } from './strategies/jwt.strategy';
 import { TokenResDto } from './dto/token.res.dto';
 
@@ -32,6 +33,7 @@ export class AuthService {
     private readonly configService: ConfigService,
     private readonly usersService: UsersService,
     private readonly redisService: RedisService,
+    private readonly preferencesService: PreferencesService,
   ) {}
 
   async loginWithCode(code: string): Promise<TokenResDto> {
@@ -74,7 +76,10 @@ export class AuthService {
     await this.redisService.del(`refresh:${userId}`);
   }
 
-  private async issueTokens(userId: string, email: string | null): Promise<TokenResDto> {
+  private async issueTokens(
+    userId: string,
+    email: string | null,
+  ): Promise<TokenResDto> {
     const payload: JwtPayload = { sub: userId, email };
 
     const accessToken = this.jwtService.sign(payload);
@@ -86,19 +91,27 @@ export class AuthService {
     const hashed = await bcrypt.hash(refreshToken, 10);
     await this.redisService.set(`refresh:${userId}`, hashed, REFRESH_TTL);
 
-    return { accessToken, refreshToken };
+    const onboarded = !!(await this.preferencesService.findByUserId(userId));
+
+    return { accessToken, refreshToken, onboarded };
   }
 
   private async exchangeCode(code: string): Promise<SpotifyTokenResponse> {
     const clientId = this.configService.get<string>('SPOTIFY_CLIENT_ID');
-    const clientSecret = this.configService.get<string>('SPOTIFY_CLIENT_SECRET');
+    const clientSecret = this.configService.get<string>(
+      'SPOTIFY_CLIENT_SECRET',
+    );
     const callbackUrl = this.configService.get<string>('SPOTIFY_CALLBACK_URL');
 
     if (!clientId || !clientSecret || !callbackUrl) {
-      throw new Error('Spotify configuration (ID, Secret, or Callback URL) is missing');
+      throw new Error(
+        'Spotify configuration (ID, Secret, or Callback URL) is missing',
+      );
     }
 
-    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString(
+      'base64',
+    );
 
     const response = await fetch('https://accounts.spotify.com/api/token', {
       method: 'POST',
@@ -120,7 +133,9 @@ export class AuthService {
     return response.json() as Promise<SpotifyTokenResponse>;
   }
 
-  private async getSpotifyProfile(accessToken: string): Promise<SpotifyProfile> {
+  private async getSpotifyProfile(
+    accessToken: string,
+  ): Promise<SpotifyProfile> {
     const response = await fetch('https://api.spotify.com/v1/me', {
       headers: { Authorization: `Bearer ${accessToken}` },
     });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -91,7 +91,7 @@ export class AuthService {
     const hashed = await bcrypt.hash(refreshToken, 10);
     await this.redisService.set(`refresh:${userId}`, hashed, REFRESH_TTL);
 
-    const onboarded = !!(await this.preferencesService.findByUserId(userId));
+    const onboarded = await this.preferencesService.existsByUserId(userId);
 
     return { accessToken, refreshToken, onboarded };
   }

--- a/src/auth/dto/token.res.dto.ts
+++ b/src/auth/dto/token.res.dto.ts
@@ -1,4 +1,5 @@
 export class TokenResDto {
   accessToken: string;
   refreshToken?: string;
+  onboarded: boolean;
 }

--- a/src/preferences/preferences.service.ts
+++ b/src/preferences/preferences.service.ts
@@ -15,6 +15,10 @@ export class PreferencesService {
     return this.preferencesRepository.findOne({ where: { userId } });
   }
 
+  existsByUserId(userId: string): Promise<boolean> {
+    return this.preferencesRepository.existsBy({ userId });
+  }
+
   async getByUserId(userId: string): Promise<UserPreference> {
     const preference = await this.findByUserId(userId);
     if (!preference) {

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,0 +1,304 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import * as request from 'supertest';
+import { AuthController } from '../src/auth/auth.controller';
+import { AuthService } from '../src/auth/auth.service';
+import { JwtStrategy } from '../src/auth/strategies/jwt.strategy';
+import { UsersService } from '../src/users/users.service';
+import { RedisService } from '../src/redis/redis.service';
+import { PreferencesService } from '../src/preferences/preferences.service';
+import { PreferencesController } from '../src/preferences/preferences.controller';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+
+const TEST_ENV = {
+  JWT_SECRET: 'test-access-secret',
+  JWT_REFRESH_SECRET: 'test-refresh-secret',
+  SPOTIFY_CLIENT_ID: 'client-id',
+  SPOTIFY_CLIENT_SECRET: 'client-secret',
+  SPOTIFY_CALLBACK_URL: 'nochu://auth/spotify/callback',
+};
+
+const SPOTIFY_PROFILE = {
+  id: 'spotify-123',
+  display_name: 'Test User',
+  email: 'test@example.com',
+  images: [{ url: 'https://img.example/avatar.png' }],
+};
+
+class FakeUsersService {
+  private store = new Map<string, any>();
+  private seq = 0;
+  createSpy = jest.fn();
+
+  reset() {
+    this.store.clear();
+    this.seq = 0;
+    this.createSpy.mockClear();
+  }
+
+  findBySpotifyId(spotifyId: string) {
+    const found = [...this.store.values()].find(
+      (u) => u.spotifyId === spotifyId,
+    );
+    return Promise.resolve(found ?? null);
+  }
+
+  create(data: any) {
+    this.createSpy(data);
+    const user = { id: `user-${++this.seq}`, ...data };
+    this.store.set(user.id, user);
+    return Promise.resolve(user);
+  }
+}
+
+class FakeRedisService {
+  store = new Map<string, string>();
+
+  reset() {
+    this.store.clear();
+  }
+
+  set(key: string, value: string) {
+    this.store.set(key, value);
+    return Promise.resolve();
+  }
+
+  get(key: string) {
+    return Promise.resolve(this.store.get(key) ?? null);
+  }
+
+  del(key: string) {
+    this.store.delete(key);
+    return Promise.resolve();
+  }
+}
+
+class FakePreferencesService {
+  private store = new Map<string, any>();
+
+  reset() {
+    this.store.clear();
+  }
+
+  findByUserId(userId: string) {
+    return Promise.resolve(this.store.get(userId) ?? null);
+  }
+
+  upsert(userId: string, data: any) {
+    const preference = { id: `pref-${userId}`, userId, data };
+    this.store.set(userId, preference);
+    return Promise.resolve(preference);
+  }
+}
+
+const VALID_PREFERENCE = {
+  genre: ['pop'],
+  emotionDirection: [{ emotion: 'sad', direction: 'comfort' }],
+  artist: ['IU'],
+  language: ['ko'],
+  bpm: { min: 80, max: 120 },
+};
+
+function mockSpotifySuccess() {
+  (global.fetch as jest.Mock)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: 'spotify-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          refresh_token: 'spotify-refresh-token',
+          scope: '',
+        }),
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(SPOTIFY_PROFILE),
+    });
+}
+
+describe('Auth (e2e)', () => {
+  let app: INestApplication;
+  let users: FakeUsersService;
+  let redis: FakeRedisService;
+  let prefs: FakePreferencesService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          ignoreEnvFile: true,
+          load: [() => TEST_ENV],
+        }),
+        PassportModule,
+        JwtModule.registerAsync({
+          inject: [ConfigService],
+          useFactory: (config: ConfigService) => ({
+            secret: config.get<string>('JWT_SECRET'),
+            signOptions: { expiresIn: '15m' },
+          }),
+        }),
+      ],
+      controllers: [AuthController, PreferencesController],
+      providers: [
+        AuthService,
+        JwtStrategy,
+        { provide: UsersService, useClass: FakeUsersService },
+        { provide: RedisService, useClass: FakeRedisService },
+        { provide: PreferencesService, useClass: FakePreferencesService },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+
+    users = app.get(UsersService);
+    redis = app.get(RedisService);
+    prefs = app.get(PreferencesService);
+  });
+
+  beforeEach(() => {
+    users.reset();
+    redis.reset();
+    prefs.reset();
+    global.fetch = jest.fn();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  async function login() {
+    mockSpotifySuccess();
+    const res = await request(app.getHttpServer())
+      .post('/auth/spotify')
+      .send({ code: 'auth-code' })
+      .expect(200);
+    return res.body as {
+      accessToken: string;
+      refreshToken: string;
+      onboarded: boolean;
+    };
+  }
+
+  describe('POST /auth/spotify', () => {
+    it('creates a new user on first login and returns tokens', async () => {
+      mockSpotifySuccess();
+
+      const res = await request(app.getHttpServer())
+        .post('/auth/spotify')
+        .send({ code: 'auth-code' })
+        .expect(200);
+
+      expect(typeof res.body.accessToken).toBe('string');
+      expect(typeof res.body.refreshToken).toBe('string');
+      expect(res.body.onboarded).toBe(false);
+      expect(users.createSpy).toHaveBeenCalledTimes(1);
+      expect(users.createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spotifyId: SPOTIFY_PROFILE.id,
+          email: SPOTIFY_PROFILE.email,
+          displayName: SPOTIFY_PROFILE.display_name,
+        }),
+      );
+    });
+
+    it('reuses the existing user on repeat login', async () => {
+      await login();
+      await login();
+
+      expect(users.createSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 401 when Spotify code exchange fails', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+
+      await request(app.getHttpServer())
+        .post('/auth/spotify')
+        .send({ code: 'bad-code' })
+        .expect(401);
+    });
+
+    it('returns 400 when code is missing', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/spotify')
+        .send({})
+        .expect(400);
+    });
+  });
+
+  describe('POST /auth/refresh', () => {
+    it('issues new tokens for a valid refresh token', async () => {
+      const { refreshToken } = await login();
+
+      const res = await request(app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken })
+        .expect(200);
+
+      expect(typeof res.body.accessToken).toBe('string');
+      expect(typeof res.body.refreshToken).toBe('string');
+    });
+
+    it('returns 401 for an invalid refresh token', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken: 'not-a-valid-token' })
+        .expect(401);
+    });
+  });
+
+  describe('DELETE /auth/logout', () => {
+    it('invalidates the refresh token and returns 204', async () => {
+      const { accessToken, refreshToken } = await login();
+
+      await request(app.getHttpServer())
+        .delete('/auth/logout')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(204);
+
+      await request(app.getHttpServer())
+        .post('/auth/refresh')
+        .send({ refreshToken })
+        .expect(401);
+    });
+
+    it('returns 401 without an access token', async () => {
+      await request(app.getHttpServer())
+        .delete('/auth/logout')
+        .expect(401);
+    });
+  });
+
+  describe('onboarding flag', () => {
+    it('is false on first login and true after preferences are submitted', async () => {
+      const first = await login();
+      expect(first.onboarded).toBe(false);
+
+      await request(app.getHttpServer())
+        .post('/preferences')
+        .set('Authorization', `Bearer ${first.accessToken}`)
+        .send(VALID_PREFERENCE)
+        .expect(201);
+
+      const second = await login();
+      expect(second.onboarded).toBe(true);
+    });
+  });
+});

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -109,6 +109,10 @@ class FakePreferencesService {
     return Promise.resolve(this.store.get(userId) ?? null);
   }
 
+  existsByUserId(userId: string): Promise<boolean> {
+    return Promise.resolve(this.store.has(userId));
+  }
+
   upsert(
     userId: string,
     data: Record<string, unknown>,

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -28,8 +28,30 @@ const SPOTIFY_PROFILE = {
   images: [{ url: 'https://img.example/avatar.png' }],
 };
 
+const VALID_PREFERENCE = {
+  genre: ['pop'],
+  emotionDirection: [{ emotion: 'sad', direction: 'comfort' }],
+  artist: ['IU'],
+  language: ['ko'],
+  bpm: { min: 80, max: 120 },
+};
+
+interface StoredUser {
+  id: string;
+  spotifyId: string;
+  email: string | null;
+  displayName: string;
+  profileImageUrl: string | null;
+}
+
+interface TokenResponse {
+  accessToken: string;
+  refreshToken: string;
+  onboarded: boolean;
+}
+
 class FakeUsersService {
-  private store = new Map<string, any>();
+  private store = new Map<string, StoredUser>();
   private seq = 0;
   createSpy = jest.fn();
 
@@ -39,86 +61,80 @@ class FakeUsersService {
     this.createSpy.mockClear();
   }
 
-  findBySpotifyId(spotifyId: string) {
+  findBySpotifyId(spotifyId: string): Promise<StoredUser | null> {
     const found = [...this.store.values()].find(
       (u) => u.spotifyId === spotifyId,
     );
     return Promise.resolve(found ?? null);
   }
 
-  create(data: any) {
+  create(data: Omit<StoredUser, 'id'>): Promise<StoredUser> {
     this.createSpy(data);
-    const user = { id: `user-${++this.seq}`, ...data };
+    const user: StoredUser = { id: `user-${++this.seq}`, ...data };
     this.store.set(user.id, user);
     return Promise.resolve(user);
   }
 }
 
 class FakeRedisService {
-  store = new Map<string, string>();
+  private store = new Map<string, string>();
 
   reset() {
     this.store.clear();
   }
 
-  set(key: string, value: string) {
+  set(key: string, value: string, _ttl?: number): Promise<void> {
     this.store.set(key, value);
     return Promise.resolve();
   }
 
-  get(key: string) {
+  get(key: string): Promise<string | null> {
     return Promise.resolve(this.store.get(key) ?? null);
   }
 
-  del(key: string) {
+  del(key: string): Promise<void> {
     this.store.delete(key);
     return Promise.resolve();
   }
 }
 
 class FakePreferencesService {
-  private store = new Map<string, any>();
+  private store = new Map<string, Record<string, unknown>>();
 
   reset() {
     this.store.clear();
   }
 
-  findByUserId(userId: string) {
+  findByUserId(userId: string): Promise<Record<string, unknown> | null> {
     return Promise.resolve(this.store.get(userId) ?? null);
   }
 
-  upsert(userId: string, data: any) {
+  upsert(
+    userId: string,
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
     const preference = { id: `pref-${userId}`, userId, data };
     this.store.set(userId, preference);
     return Promise.resolve(preference);
   }
 }
 
-const VALID_PREFERENCE = {
-  genre: ['pop'],
-  emotionDirection: [{ emotion: 'sad', direction: 'comfort' }],
-  artist: ['IU'],
-  language: ['ko'],
-  bpm: { min: 80, max: 120 },
-};
+function jsonResponse(ok: boolean, body: unknown): Response {
+  return { ok, json: () => Promise.resolve(body) } as unknown as Response;
+}
 
-function mockSpotifySuccess() {
-  (global.fetch as jest.Mock)
-    .mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          access_token: 'spotify-access-token',
-          token_type: 'Bearer',
-          expires_in: 3600,
-          refresh_token: 'spotify-refresh-token',
-          scope: '',
-        }),
-    })
-    .mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(SPOTIFY_PROFILE),
-    });
+function mockSpotifySuccess(fetchMock: jest.SpyInstance) {
+  fetchMock
+    .mockResolvedValueOnce(
+      jsonResponse(true, {
+        access_token: 'spotify-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: 'spotify-refresh-token',
+        scope: '',
+      }),
+    )
+    .mockResolvedValueOnce(jsonResponse(true, SPOTIFY_PROFILE));
 }
 
 describe('Auth (e2e)', () => {
@@ -126,6 +142,7 @@ describe('Auth (e2e)', () => {
   let users: FakeUsersService;
   let redis: FakeRedisService;
   let prefs: FakePreferencesService;
+  let fetchMock: jest.SpyInstance;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -174,38 +191,39 @@ describe('Auth (e2e)', () => {
     users.reset();
     redis.reset();
     prefs.reset();
-    global.fetch = jest.fn();
+    fetchMock = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   afterAll(async () => {
     await app.close();
   });
 
-  async function login() {
-    mockSpotifySuccess();
+  async function login(): Promise<TokenResponse> {
+    mockSpotifySuccess(fetchMock);
     const res = await request(app.getHttpServer())
       .post('/auth/spotify')
       .send({ code: 'auth-code' })
       .expect(200);
-    return res.body as {
-      accessToken: string;
-      refreshToken: string;
-      onboarded: boolean;
-    };
+    return res.body as TokenResponse;
   }
 
   describe('POST /auth/spotify', () => {
     it('creates a new user on first login and returns tokens', async () => {
-      mockSpotifySuccess();
+      mockSpotifySuccess(fetchMock);
 
       const res = await request(app.getHttpServer())
         .post('/auth/spotify')
         .send({ code: 'auth-code' })
         .expect(200);
 
-      expect(typeof res.body.accessToken).toBe('string');
-      expect(typeof res.body.refreshToken).toBe('string');
-      expect(res.body.onboarded).toBe(false);
+      const body = res.body as TokenResponse;
+      expect(typeof body.accessToken).toBe('string');
+      expect(typeof body.refreshToken).toBe('string');
+      expect(body.onboarded).toBe(false);
       expect(users.createSpy).toHaveBeenCalledTimes(1);
       expect(users.createSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -224,10 +242,7 @@ describe('Auth (e2e)', () => {
     });
 
     it('returns 401 when Spotify code exchange fails', async () => {
-      (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: false,
-        json: () => Promise.resolve({}),
-      });
+      fetchMock.mockResolvedValueOnce(jsonResponse(false, {}));
 
       await request(app.getHttpServer())
         .post('/auth/spotify')
@@ -252,8 +267,9 @@ describe('Auth (e2e)', () => {
         .send({ refreshToken })
         .expect(200);
 
-      expect(typeof res.body.accessToken).toBe('string');
-      expect(typeof res.body.refreshToken).toBe('string');
+      const body = res.body as TokenResponse;
+      expect(typeof body.accessToken).toBe('string');
+      expect(typeof body.refreshToken).toBe('string');
     });
 
     it('returns 401 for an invalid refresh token', async () => {
@@ -280,9 +296,7 @@ describe('Auth (e2e)', () => {
     });
 
     it('returns 401 without an access token', async () => {
-      await request(app.getHttpServer())
-        .delete('/auth/logout')
-        .expect(401);
+      await request(app.getHttpServer()).delete('/auth/logout').expect(401);
     });
   });
 


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 로그인/토큰 갱신 응답(TokenResDto)에 onboarded 플래그 추가 (preference 존재 여부로 판정)
- 최초 Spotify 로그인 시 onboarded=false → 클라이언트가 온보딩 화면 노출 판단 가능, 성향 제출 후 재로그인 시 true
- AuthService가 PreferencesService를 주입받아 issueTokens에서 온보딩 여부 계산
- 회원가입/로그인 e2e 테스트 추가: 신규/기존 유저, 코드 교환 실패(401), 유효성(400), refresh 발급/실패, logout 무효화, 온보딩 플래그 전환

## 💬리뷰 요구사항(선택)

> e2e는 외부 의존(Spotify fetch, DB, Redis)을 인메모리 페이크/목으로 격리하고 JWT는 실제 서명·검증으로 돌립니다. onboarded는 login/refresh 양쪽 응답에 일관되게 포함됩니다