### PR TITLE
preferences 요청 본문을 단일 data json 필드로 변경

### DIFF
--- a/src/preferences/dto/create-preference.req.dto.ts
+++ b/src/preferences/dto/create-preference.req.dto.ts
@@ -1,41 +1,6 @@
-import { Type } from 'class-transformer';
-import { IsArray, IsNumber, IsString, ValidateNested } from 'class-validator';
-
-export class EmotionDirectionDto {
-  @IsString()
-  emotion: string;
-
-  @IsString()
-  direction: string;
-}
-
-export class BpmRangeDto {
-  @IsNumber()
-  min: number;
-
-  @IsNumber()
-  max: number;
-}
+import { IsObject } from 'class-validator';
 
 export class CreatePreferenceReqDto {
-  @IsArray()
-  @IsString({ each: true })
-  genre: string[];
-
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => EmotionDirectionDto)
-  emotionDirection: EmotionDirectionDto[];
-
-  @IsArray()
-  @IsString({ each: true })
-  artist: string[];
-
-  @IsArray()
-  @IsString({ each: true })
-  language: string[];
-
-  @ValidateNested()
-  @Type(() => BpmRangeDto)
-  bpm: BpmRangeDto;
+  @IsObject()
+  data: Record<string, unknown>;
 }

--- a/src/preferences/dto/preference.res.dto.ts
+++ b/src/preferences/dto/preference.res.dto.ts
@@ -1,5 +1,5 @@
 import { Expose, plainToInstance } from 'class-transformer';
-import { PreferenceData, UserPreference } from '../user-preference.entity';
+import { UserPreference } from '../user-preference.entity';
 
 export class PreferenceResDto {
   @Expose()
@@ -9,7 +9,7 @@ export class PreferenceResDto {
   userId: string;
 
   @Expose()
-  data: PreferenceData;
+  data: Record<string, unknown>;
 
   @Expose()
   createdAt: Date;

--- a/src/preferences/dto/update-preference.req.dto.ts
+++ b/src/preferences/dto/update-preference.req.dto.ts
@@ -1,31 +1,7 @@
-import { Type } from 'class-transformer';
-import { IsArray, IsOptional, IsString, ValidateNested } from 'class-validator';
-import { BpmRangeDto, EmotionDirectionDto } from './create-preference.req.dto';
+import { IsObject, IsOptional } from 'class-validator';
 
 export class UpdatePreferenceReqDto {
   @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  genre?: string[];
-
-  @IsOptional()
-  @IsArray()
-  @ValidateNested({ each: true })
-  @Type(() => EmotionDirectionDto)
-  emotionDirection?: EmotionDirectionDto[];
-
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  artist?: string[];
-
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  language?: string[];
-
-  @IsOptional()
-  @ValidateNested()
-  @Type(() => BpmRangeDto)
-  bpm?: BpmRangeDto;
+  @IsObject()
+  data?: Record<string, unknown>;
 }

--- a/src/preferences/dto/update-preference.req.dto.ts
+++ b/src/preferences/dto/update-preference.req.dto.ts
@@ -1,7 +1,6 @@
-import { IsObject, IsOptional } from 'class-validator';
+import { IsObject } from 'class-validator';
 
 export class UpdatePreferenceReqDto {
-  @IsOptional()
   @IsObject()
-  data?: Record<string, unknown>;
+  data: Record<string, unknown>;
 }

--- a/src/preferences/preferences.controller.ts
+++ b/src/preferences/preferences.controller.ts
@@ -29,7 +29,7 @@ export class PreferencesController {
     @Body() dto: CreatePreferenceReqDto,
   ): Promise<PreferenceResDto> {
     const { sub } = req.user as JwtPayload;
-    const preference = await this.preferencesService.upsert(sub, dto);
+    const preference = await this.preferencesService.upsert(sub, dto.data);
     return PreferenceResDto.from(preference);
   }
 
@@ -46,7 +46,7 @@ export class PreferencesController {
     @Body() dto: UpdatePreferenceReqDto,
   ): Promise<PreferenceResDto> {
     const { sub } = req.user as JwtPayload;
-    const preference = await this.preferencesService.patch(sub, dto);
+    const preference = await this.preferencesService.patch(sub, dto.data ?? {});
     return PreferenceResDto.from(preference);
   }
 }

--- a/src/preferences/preferences.controller.ts
+++ b/src/preferences/preferences.controller.ts
@@ -46,7 +46,7 @@ export class PreferencesController {
     @Body() dto: UpdatePreferenceReqDto,
   ): Promise<PreferenceResDto> {
     const { sub } = req.user as JwtPayload;
-    const preference = await this.preferencesService.patch(sub, dto.data ?? {});
+    const preference = await this.preferencesService.patch(sub, dto.data);
     return PreferenceResDto.from(preference);
   }
 }

--- a/src/preferences/preferences.service.spec.ts
+++ b/src/preferences/preferences.service.spec.ts
@@ -30,6 +30,7 @@ describe('PreferencesService', () => {
             create: jest.fn(),
             save: jest.fn(),
             update: jest.fn(),
+            existsBy: jest.fn(),
           },
         },
       ],
@@ -50,6 +51,19 @@ describe('PreferencesService', () => {
       await expect(service.getByUserId(userId)).rejects.toBeInstanceOf(
         NotFoundException,
       );
+    });
+  });
+
+  describe('existsByUserId', () => {
+    it('returns true when a preference exists', async () => {
+      repository.existsBy.mockResolvedValue(true);
+      await expect(service.existsByUserId(userId)).resolves.toBe(true);
+      expect(repository.existsBy).toHaveBeenCalledWith({ userId });
+    });
+
+    it('returns false when no preference exists', async () => {
+      repository.existsBy.mockResolvedValue(false);
+      await expect(service.existsByUserId(userId)).resolves.toBe(false);
     });
   });
 

--- a/src/preferences/preferences.service.spec.ts
+++ b/src/preferences/preferences.service.spec.ts
@@ -3,14 +3,14 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { NotFoundException } from '../common/exceptions/not-found.exception';
 import { PreferencesService } from './preferences.service';
-import { PreferenceData, UserPreference } from './user-preference.entity';
+import { UserPreference } from './user-preference.entity';
 
 describe('PreferencesService', () => {
   let service: PreferencesService;
   let repository: jest.Mocked<Repository<UserPreference>>;
 
   const userId = 'user-1';
-  const data: PreferenceData = {
+  const data: Record<string, unknown> = {
     genre: ['pop'],
     emotionDirection: [{ emotion: 'sad', direction: 'comfort' }],
     artist: ['IU'],

--- a/src/preferences/preferences.service.ts
+++ b/src/preferences/preferences.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { NotFoundException } from '../common/exceptions/not-found.exception';
-import { PreferenceData, UserPreference } from './user-preference.entity';
+import { UserPreference } from './user-preference.entity';
 
 @Injectable()
 export class PreferencesService {
@@ -27,7 +27,10 @@ export class PreferencesService {
     return preference;
   }
 
-  async upsert(userId: string, data: PreferenceData): Promise<UserPreference> {
+  async upsert(
+    userId: string,
+    data: Record<string, unknown>,
+  ): Promise<UserPreference> {
     const existing = await this.findByUserId(userId);
     if (existing) {
       existing.data = data;
@@ -39,7 +42,7 @@ export class PreferencesService {
 
   async patch(
     userId: string,
-    partial: Partial<PreferenceData>,
+    partial: Record<string, unknown>,
   ): Promise<UserPreference> {
     const preference = await this.getByUserId(userId);
     preference.data = { ...preference.data, ...partial };

--- a/src/preferences/user-preference.entity.ts
+++ b/src/preferences/user-preference.entity.ts
@@ -9,24 +9,6 @@ import {
 } from 'typeorm';
 import { User } from '../users/user.entity';
 
-export interface EmotionDirection {
-  emotion: string;
-  direction: string;
-}
-
-export interface BpmRange {
-  min: number;
-  max: number;
-}
-
-export interface PreferenceData {
-  genre: string[];
-  emotionDirection: EmotionDirection[];
-  artist: string[];
-  language: string[];
-  bpm: BpmRange;
-}
-
 @Entity('user_preferences')
 export class UserPreference {
   @PrimaryGeneratedColumn('uuid')
@@ -36,7 +18,7 @@ export class UserPreference {
   userId: string;
 
   @Column({ type: 'jsonb' })
-  data: PreferenceData;
+  data: Record<string, unknown>;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -312,7 +312,7 @@ describe('Auth (e2e)', () => {
       await request(app.getHttpServer())
         .post('/preferences')
         .set('Authorization', `Bearer ${first.accessToken}`)
-        .send(VALID_PREFERENCE)
+        .send({ data: VALID_PREFERENCE })
         .expect(201);
 
       const second = await login();

--- a/test/preferences.e2e-spec.ts
+++ b/test/preferences.e2e-spec.ts
@@ -203,5 +203,11 @@ describe('Preferences (e2e)', () => {
         .send({ data: { genre: ['rock'] } })
         .expect(404);
     });
+
+    it('returns 400 on an empty body', async () => {
+      await auth(request(app.getHttpServer()).patch('/preferences'))
+        .send({})
+        .expect(400);
+    });
   });
 });

--- a/test/preferences.e2e-spec.ts
+++ b/test/preferences.e2e-spec.ts
@@ -1,0 +1,207 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import * as request from 'supertest';
+import { PreferencesController } from '../src/preferences/preferences.controller';
+import { PreferencesService } from '../src/preferences/preferences.service';
+import { UserPreference } from '../src/preferences/user-preference.entity';
+import { JwtStrategy } from '../src/auth/strategies/jwt.strategy';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+
+const TEST_ENV = { JWT_SECRET: 'test-access-secret' };
+
+const SURVEY = {
+  genre: ['pop'],
+  emotionDirection: [{ emotion: 'sad', direction: 'comfort' }],
+  artist: ['IU'],
+  language: ['ko'],
+  bpm: { min: 80, max: 120 },
+};
+
+interface StoredPreference {
+  id: string;
+  userId: string;
+  data: Record<string, unknown>;
+}
+
+class FakePreferenceRepository {
+  private store = new Map<string, StoredPreference>();
+
+  reset() {
+    this.store.clear();
+  }
+
+  findOne(options: {
+    where: { userId: string };
+  }): Promise<StoredPreference | null> {
+    return Promise.resolve(this.store.get(options.where.userId) ?? null);
+  }
+
+  existsBy(where: { userId: string }): Promise<boolean> {
+    return Promise.resolve(this.store.has(where.userId));
+  }
+
+  create(data: {
+    userId: string;
+    data: Record<string, unknown>;
+  }): StoredPreference {
+    return { id: `pref-${data.userId}`, ...data };
+  }
+
+  save(entity: StoredPreference): Promise<StoredPreference> {
+    this.store.set(entity.userId, entity);
+    return Promise.resolve(entity);
+  }
+}
+
+describe('Preferences (e2e)', () => {
+  let app: INestApplication;
+  let repo: FakePreferenceRepository;
+  let token: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          ignoreEnvFile: true,
+          load: [() => TEST_ENV],
+        }),
+        PassportModule,
+        JwtModule.registerAsync({
+          inject: [ConfigService],
+          useFactory: (config: ConfigService) => ({
+            secret: config.get<string>('JWT_SECRET'),
+            signOptions: { expiresIn: '15m' },
+          }),
+        }),
+      ],
+      controllers: [PreferencesController],
+      providers: [
+        PreferencesService,
+        JwtStrategy,
+        {
+          provide: getRepositoryToken(UserPreference),
+          useClass: FakePreferenceRepository,
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+
+    repo = app.get(getRepositoryToken(UserPreference));
+    token = app.get(JwtService).sign({ sub: 'user-1', email: null });
+  });
+
+  beforeEach(() => {
+    repo.reset();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  function auth(req: request.Test): request.Test {
+    return req.set('Authorization', `Bearer ${token}`);
+  }
+
+  describe('POST /preferences', () => {
+    it('stores the survey and returns 201', async () => {
+      const res = await auth(request(app.getHttpServer()).post('/preferences'))
+        .send({ data: SURVEY })
+        .expect(201);
+
+      const body = res.body as StoredPreference;
+      expect(body.data).toEqual(SURVEY);
+      expect(body.userId).toBe('user-1');
+    });
+
+    it('returns 401 without a token', async () => {
+      await request(app.getHttpServer())
+        .post('/preferences')
+        .send({ data: SURVEY })
+        .expect(401);
+    });
+
+    it('returns 400 when data is missing', async () => {
+      await auth(request(app.getHttpServer()).post('/preferences'))
+        .send({})
+        .expect(400);
+    });
+
+    it('returns 400 on non-whitelisted fields', async () => {
+      await auth(request(app.getHttpServer()).post('/preferences'))
+        .send({ data: SURVEY, extra: 'nope' })
+        .expect(400);
+    });
+
+    it('overwrites on repeat submit', async () => {
+      await auth(request(app.getHttpServer()).post('/preferences'))
+        .send({ data: SURVEY })
+        .expect(201);
+
+      const res = await auth(request(app.getHttpServer()).post('/preferences'))
+        .send({ data: { genre: ['jazz'] } })
+        .expect(201);
+
+      expect((res.body as StoredPreference).data).toEqual({ genre: ['jazz'] });
+    });
+  });
+
+  describe('GET /preferences', () => {
+    it('returns the stored survey', async () => {
+      await auth(request(app.getHttpServer()).post('/preferences'))
+        .send({ data: SURVEY })
+        .expect(201);
+
+      const res = await auth(
+        request(app.getHttpServer()).get('/preferences'),
+      ).expect(200);
+
+      expect((res.body as StoredPreference).data).toEqual(SURVEY);
+    });
+
+    it('returns 404 when not onboarded', async () => {
+      await auth(request(app.getHttpServer()).get('/preferences')).expect(404);
+    });
+
+    it('returns 401 without a token', async () => {
+      await request(app.getHttpServer()).get('/preferences').expect(401);
+    });
+  });
+
+  describe('PATCH /preferences', () => {
+    it('merges into the stored survey', async () => {
+      await auth(request(app.getHttpServer()).post('/preferences'))
+        .send({ data: SURVEY })
+        .expect(201);
+
+      const res = await auth(request(app.getHttpServer()).patch('/preferences'))
+        .send({ data: { genre: ['rock'] } })
+        .expect(200);
+
+      expect((res.body as StoredPreference).data).toEqual({
+        ...SURVEY,
+        genre: ['rock'],
+      });
+    });
+
+    it('returns 404 when not onboarded', async () => {
+      await auth(request(app.getHttpServer()).patch('/preferences'))
+        .send({ data: { genre: ['rock'] } })
+        .expect(404);
+    });
+  });
+});


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- POST/PATCH /preferences 요청 본문을 구조화된 5개 필드에서 단일 data json 필드로 변경
- 온보딩 설문을 통째로 JSONB에 저장해 AI 서버로 그대로 전달하는 구조에 맞춤 (설문 문항 변경 시 코드 수정 불필요)
- DTO는 data가 객체인지만 검증(@IsObject), 엔티티 data 타입을 Record<string, unknown>으로 일반화
- 관련 단위/e2e 테스트를 새 본문 형태에 맞게 갱신

## 💬리뷰 요구사항(선택)

> 요청 본문이 { "data": { ...설문... } } 형태로 바뀝니다. 컬럼은 그대로 jsonb라 마이그레이션은 불필요합니다. 필드별 검증을 버린 대신 설문 유연성을 택한 트레이드오프가 맞는지 봐주세요