### PR TITLE
감정 기반 음악 추천 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { SongsModule } from './songs/songs.module';
 import { PlaylistsModule } from './playlists/playlists.module';
 import { PreferencesModule } from './preferences/preferences.module';
 import { EmotionsModule } from './emotions/emotions.module';
+import { MusicModule } from './music/music.module';
 import { AuthModule } from './auth/auth.module';
 import { RedisModule } from './redis/redis.module';
 
@@ -21,6 +22,7 @@ import { RedisModule } from './redis/redis.module';
     PlaylistsModule,
     PreferencesModule,
     EmotionsModule,
+    MusicModule,
     AuthModule,
   ],
   controllers: [AppController],

--- a/src/database/migrations/1783297785052-MusicColumns.ts
+++ b/src/database/migrations/1783297785052-MusicColumns.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MusicColumns1783297785052 implements MigrationInterface {
+    name = 'MusicColumns1783297785052'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "songs" ADD "spotifyUrl" character varying`);
+        await queryRunner.query(`ALTER TABLE "playlists" ADD "title" character varying NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "playlists" ADD "imageUrl" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "playlists" DROP COLUMN "imageUrl"`);
+        await queryRunner.query(`ALTER TABLE "playlists" DROP COLUMN "title"`);
+        await queryRunner.query(`ALTER TABLE "songs" DROP COLUMN "spotifyUrl"`);
+    }
+
+}

--- a/src/emotions/emotions.service.ts
+++ b/src/emotions/emotions.service.ts
@@ -4,7 +4,7 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { MoreThanOrEqual, Repository } from 'typeorm';
 import { AiService } from '../ai/ai.service';
 import { S3Service } from '../storage/s3.service';
 import { Emotion } from './emotion.entity';
@@ -72,6 +72,15 @@ export class EmotionsService {
       }
       throw error;
     }
+  }
+
+  findTodayLatest(userId: string): Promise<Emotion | null> {
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    return this.emotionsRepository.findOne({
+      where: { userId, createdAt: MoreThanOrEqual(start) },
+      order: { createdAt: 'DESC' },
+    });
   }
 
   async findHistory(userId: string): Promise<EmotionHistoryResDto> {

--- a/src/emotions/emotions.service.ts
+++ b/src/emotions/emotions.service.ts
@@ -75,8 +75,11 @@ export class EmotionsService {
   }
 
   findTodayLatest(userId: string): Promise<Emotion | null> {
-    const start = new Date();
-    start.setHours(0, 0, 0, 0);
+    const KST_OFFSET = 9 * 60 * 60 * 1000;
+    const kstNow = new Date(Date.now() + KST_OFFSET);
+    kstNow.setUTCHours(0, 0, 0, 0);
+    const start = new Date(kstNow.getTime() - KST_OFFSET);
+
     return this.emotionsRepository.findOne({
       where: { userId, createdAt: MoreThanOrEqual(start) },
       order: { createdAt: 'DESC' },

--- a/src/music/dto/music-recommendation.req.dto.ts
+++ b/src/music/dto/music-recommendation.req.dto.ts
@@ -1,0 +1,7 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class MusicRecommendationReqDto {
+  @IsOptional()
+  @IsString()
+  comment?: string;
+}

--- a/src/music/music.controller.ts
+++ b/src/music/music.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { JwtPayload } from '../auth/strategies/jwt.strategy';
+import { MusicService } from './music.service';
+import { MusicRecommendationReqDto } from './dto/music-recommendation.req.dto';
+import { PlaylistResDto } from '../playlists/dto/playlist.res.dto';
+
+@ApiTags('music')
+@ApiBearerAuth()
+@Controller('music')
+@UseGuards(JwtAuthGuard)
+export class MusicController {
+  constructor(private readonly musicService: MusicService) {}
+
+  @Post()
+  @ApiOperation({ summary: '오늘 감정 기반 음악 추천 및 플레이리스트 생성' })
+  recommend(
+    @Req() req: Request,
+    @Body() dto: MusicRecommendationReqDto,
+  ): Promise<PlaylistResDto> {
+    const { sub } = req.user as JwtPayload;
+    return this.musicService.recommend(sub, dto.comment ?? null);
+  }
+}

--- a/src/music/music.module.ts
+++ b/src/music/music.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AiModule } from '../ai/ai.module';
+import { EmotionsModule } from '../emotions/emotions.module';
+import { SpotifyModule } from '../spotify/spotify.module';
+import { MusicController } from './music.controller';
+import { MusicService } from './music.service';
+
+@Module({
+  imports: [EmotionsModule, AiModule, SpotifyModule],
+  controllers: [MusicController],
+  providers: [MusicService],
+})
+export class MusicModule {}

--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -1,0 +1,129 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { MusicService } from './music.service';
+import { EmotionsService } from '../emotions/emotions.service';
+import { AiService } from '../ai/ai.service';
+import { SpotifyService } from '../spotify/spotify.service';
+import { Emotion } from '../emotions/emotion.entity';
+import { Playlist } from '../playlists/playlist.entity';
+
+describe('MusicService', () => {
+  let service: MusicService;
+  let emotionsService: { findTodayLatest: jest.Mock };
+  let aiService: { extractKeywords: jest.Mock };
+  let spotifyService: { searchTracks: jest.Mock };
+
+  const userId = 'user-1';
+  const emotion = {
+    emotion: 'happy',
+    emotions: {
+      happy: 0.8,
+      surprise: 0,
+      anger: 0,
+      anxiety: 0,
+      hurt: 0,
+      sad: 0.2,
+    },
+  } as Emotion;
+
+  const track = {
+    id: 'track-1',
+    title: 'Song A',
+    artists: ['Artist A'],
+    albumName: 'Album A',
+    albumImageUrl: 'https://img/a.png',
+    spotifyUrl: 'https://open.spotify.com/track/track-1',
+    previewUrl: null,
+    durationMs: 200000,
+  };
+
+  const savedPlaylist = {
+    id: 'pl-1',
+    title: 'Happy Mix',
+    imageUrl: 'https://img/a.png',
+    playlistSongs: [
+      {
+        rank: 0,
+        song: {
+          title: 'Song A',
+          artist: JSON.stringify(['Artist A']),
+          albumImageUrl: 'https://img/a.png',
+          spotifyUrl: 'https://open.spotify.com/track/track-1',
+          durationMs: 200000,
+        },
+      },
+    ],
+  } as Playlist;
+
+  const manager = {
+    create: jest.fn((_e: unknown, v: unknown) => v),
+    save: jest.fn((v: unknown) =>
+      Promise.resolve({ id: 'pl-1', ...(v as object) }),
+    ),
+    findOne: jest.fn().mockResolvedValue(null),
+    findOneOrFail: jest.fn().mockResolvedValue(savedPlaylist),
+  };
+
+  beforeEach(async () => {
+    emotionsService = { findTodayLatest: jest.fn() };
+    aiService = { extractKeywords: jest.fn() };
+    spotifyService = { searchTracks: jest.fn() };
+
+    const dataSource = {
+      transaction: jest.fn((cb: (m: typeof manager) => unknown) => cb(manager)),
+    };
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        MusicService,
+        { provide: getDataSourceToken(), useValue: dataSource },
+        { provide: EmotionsService, useValue: emotionsService },
+        { provide: AiService, useValue: aiService },
+        { provide: SpotifyService, useValue: spotifyService },
+      ],
+    }).compile();
+
+    service = moduleRef.get(MusicService);
+  });
+
+  it('recommends a playlist from today emotion', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    aiService.extractKeywords.mockResolvedValue({
+      keywords: 'happy upbeat',
+      title: 'Happy Mix',
+    });
+    spotifyService.searchTracks.mockResolvedValue([track]);
+
+    const result = await service.recommend(userId, 'good day');
+
+    expect(aiService.extractKeywords).toHaveBeenCalledWith(
+      emotion.emotions,
+      'good day',
+    );
+    expect(result.id).toBe('pl-1');
+    expect(result.title).toBe('Happy Mix');
+    expect(result.tracks[0].artists).toEqual(['Artist A']);
+    expect(result.tracks[0].duration).toBe('3:20');
+  });
+
+  it('throws NotFoundException when no emotion today', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(null);
+    await expect(service.recommend(userId, null)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('throws NotFoundException when spotify returns no tracks', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    aiService.extractKeywords.mockResolvedValue({
+      keywords: 'happy',
+      title: 'Mix',
+    });
+    spotifyService.searchTracks.mockResolvedValue([]);
+
+    await expect(service.recommend(userId, null)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+});

--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -58,10 +58,15 @@ describe('MusicService', () => {
 
   const manager = {
     create: jest.fn((_e: unknown, v: unknown) => v),
-    save: jest.fn((v: unknown) =>
-      Promise.resolve({ id: 'pl-1', ...(v as object) }),
-    ),
-    findOne: jest.fn().mockResolvedValue(null),
+    save: jest.fn((a: unknown, b?: unknown) => {
+      if (Array.isArray(b)) {
+        return Promise.resolve(
+          b.map((v, i) => ({ id: `row-${i}`, ...(v as object) })),
+        );
+      }
+      return Promise.resolve({ id: 'pl-1', ...(a as object) });
+    }),
+    find: jest.fn().mockResolvedValue([]),
     findOneOrFail: jest.fn().mockResolvedValue(savedPlaylist),
   };
 

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
-import { DataSource } from 'typeorm';
+import { DataSource, In } from 'typeorm';
 import { EmotionsService } from '../emotions/emotions.service';
 import { AiService } from '../ai/ai.service';
 import { SpotifyService, SpotifyTrack } from '../spotify/spotify.service';
@@ -61,33 +61,39 @@ export class MusicService {
         }),
       );
 
-      for (const [index, track] of tracks.entries()) {
-        let song = await manager.findOne(Song, {
-          where: { spotifyTrackId: track.id },
-        });
-        if (!song) {
-          song = await manager.save(
-            manager.create(Song, {
-              spotifyTrackId: track.id,
-              title: track.title,
-              artist: JSON.stringify(track.artists),
-              albumName: track.albumName,
-              albumImageUrl: track.albumImageUrl ?? undefined,
-              spotifyUrl: track.spotifyUrl ?? undefined,
-              previewUrl: track.previewUrl ?? undefined,
-              durationMs: track.durationMs,
-            }),
-          );
-        }
+      const trackIds = tracks.map((t) => t.id);
+      const existing = await manager.find(Song, {
+        where: { spotifyTrackId: In(trackIds) },
+      });
+      const songMap = new Map(existing.map((s) => [s.spotifyTrackId, s]));
 
-        await manager.save(
-          manager.create(PlaylistSong, {
-            playlistId: playlist.id,
-            songId: song.id,
-            rank: index,
+      const toInsert = tracks
+        .filter((t) => !songMap.has(t.id))
+        .map((t) =>
+          manager.create(Song, {
+            spotifyTrackId: t.id,
+            title: t.title,
+            artist: JSON.stringify(t.artists),
+            albumName: t.albumName,
+            albumImageUrl: t.albumImageUrl ?? undefined,
+            spotifyUrl: t.spotifyUrl ?? undefined,
+            previewUrl: t.previewUrl ?? undefined,
+            durationMs: t.durationMs,
           }),
         );
+      if (toInsert.length > 0) {
+        const inserted = await manager.save(Song, toInsert);
+        inserted.forEach((s) => songMap.set(s.spotifyTrackId, s));
       }
+
+      const playlistSongs = tracks.map((t, index) =>
+        manager.create(PlaylistSong, {
+          playlistId: playlist.id,
+          songId: songMap.get(t.id)!.id,
+          rank: index,
+        }),
+      );
+      await manager.save(PlaylistSong, playlistSongs);
 
       return manager.findOneOrFail(Playlist, {
         where: { id: playlist.id },

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { EmotionsService } from '../emotions/emotions.service';
+import { AiService } from '../ai/ai.service';
+import { SpotifyService, SpotifyTrack } from '../spotify/spotify.service';
+import { Playlist } from '../playlists/playlist.entity';
+import { PlaylistSong } from '../playlists/playlist-song.entity';
+import { Song } from '../songs/song.entity';
+import { PlaylistResDto } from '../playlists/dto/playlist.res.dto';
+
+@Injectable()
+export class MusicService {
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    private readonly emotionsService: EmotionsService,
+    private readonly aiService: AiService,
+    private readonly spotifyService: SpotifyService,
+  ) {}
+
+  async recommend(
+    userId: string,
+    comment: string | null,
+  ): Promise<PlaylistResDto> {
+    const emotion = await this.emotionsService.findTodayLatest(userId);
+    if (!emotion) {
+      throw new NotFoundException('No emotion analysis found for today');
+    }
+
+    const { keywords, title } = await this.aiService.extractKeywords(
+      emotion.emotions,
+      comment,
+    );
+    if (!keywords?.trim()) {
+      throw new NotFoundException('No music keywords available');
+    }
+
+    const tracks = await this.spotifyService.searchTracks(keywords);
+    if (tracks.length === 0) {
+      throw new NotFoundException('No tracks found');
+    }
+
+    const playlist = await this.save(userId, emotion.emotion, title, tracks);
+    return PlaylistResDto.from(playlist);
+  }
+
+  private save(
+    userId: string,
+    emotionLabel: string,
+    title: string,
+    tracks: SpotifyTrack[],
+  ): Promise<Playlist> {
+    return this.dataSource.transaction(async (manager) => {
+      const playlist = await manager.save(
+        manager.create(Playlist, {
+          userId,
+          title,
+          imageUrl: tracks[0].albumImageUrl ?? undefined,
+          emotionLabel,
+        }),
+      );
+
+      for (const [index, track] of tracks.entries()) {
+        let song = await manager.findOne(Song, {
+          where: { spotifyTrackId: track.id },
+        });
+        if (!song) {
+          song = await manager.save(
+            manager.create(Song, {
+              spotifyTrackId: track.id,
+              title: track.title,
+              artist: JSON.stringify(track.artists),
+              albumName: track.albumName,
+              albumImageUrl: track.albumImageUrl ?? undefined,
+              spotifyUrl: track.spotifyUrl ?? undefined,
+              previewUrl: track.previewUrl ?? undefined,
+              durationMs: track.durationMs,
+            }),
+          );
+        }
+
+        await manager.save(
+          manager.create(PlaylistSong, {
+            playlistId: playlist.id,
+            songId: song.id,
+            rank: index,
+          }),
+        );
+      }
+
+      return manager.findOneOrFail(Playlist, {
+        where: { id: playlist.id },
+        relations: ['playlistSongs', 'playlistSongs.song'],
+      });
+    });
+  }
+}

--- a/src/playlists/dto/playlist.res.dto.ts
+++ b/src/playlists/dto/playlist.res.dto.ts
@@ -8,6 +8,15 @@ export interface PlaylistTrackDto {
   duration: string;
 }
 
+function parseArtists(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as string[];
+  } catch {
+    return [raw];
+  }
+}
+
 function formatDuration(durationMs: number): string {
   const totalSeconds = Math.floor(durationMs / 1000);
   const minutes = Math.floor(totalSeconds / 60);
@@ -29,7 +38,7 @@ export class PlaylistResDto {
     dto.tracks = [...(playlist.playlistSongs ?? [])]
       .sort((a, b) => a.rank - b.rank)
       .map((ps) => ({
-        artists: ps.song.artist ? (JSON.parse(ps.song.artist) as string[]) : [],
+        artists: parseArtists(ps.song.artist),
         title: ps.song.title,
         imageUrl: ps.song.albumImageUrl ?? null,
         spotifyUrl: ps.song.spotifyUrl ?? null,

--- a/src/playlists/dto/playlist.res.dto.ts
+++ b/src/playlists/dto/playlist.res.dto.ts
@@ -1,0 +1,40 @@
+import { Playlist } from '../playlist.entity';
+
+export interface PlaylistTrackDto {
+  artists: string[];
+  title: string;
+  imageUrl: string | null;
+  spotifyUrl: string | null;
+  duration: string;
+}
+
+function formatDuration(durationMs: number): string {
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+export class PlaylistResDto {
+  id: string;
+  title: string;
+  imageUrl: string | null;
+  tracks: PlaylistTrackDto[];
+
+  static from(playlist: Playlist): PlaylistResDto {
+    const dto = new PlaylistResDto();
+    dto.id = playlist.id;
+    dto.title = playlist.title;
+    dto.imageUrl = playlist.imageUrl ?? null;
+    dto.tracks = [...(playlist.playlistSongs ?? [])]
+      .sort((a, b) => a.rank - b.rank)
+      .map((ps) => ({
+        artists: ps.song.artist ? (JSON.parse(ps.song.artist) as string[]) : [],
+        title: ps.song.title,
+        imageUrl: ps.song.albumImageUrl ?? null,
+        spotifyUrl: ps.song.spotifyUrl ?? null,
+        duration: formatDuration(ps.song.durationMs),
+      }));
+    return dto;
+  }
+}

--- a/src/playlists/playlist.entity.ts
+++ b/src/playlists/playlist.entity.ts
@@ -17,6 +17,12 @@ export class Playlist {
   @Column()
   userId: string;
 
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  imageUrl: string;
+
   @Column({ nullable: true })
   emotionLabel: string;
 
@@ -35,6 +41,8 @@ export class Playlist {
   @ManyToOne(() => User, (user) => user.playlists, { onDelete: 'CASCADE' })
   user: User;
 
-  @OneToMany(() => PlaylistSong, (playlistSong) => playlistSong.playlist, { cascade: true })
+  @OneToMany(() => PlaylistSong, (playlistSong) => playlistSong.playlist, {
+    cascade: true,
+  })
   playlistSongs: PlaylistSong[];
 }

--- a/src/songs/song.entity.ts
+++ b/src/songs/song.entity.ts
@@ -28,6 +28,9 @@ export class Song {
   albumImageUrl: string;
 
   @Column({ nullable: true })
+  spotifyUrl: string;
+
+  @Column({ nullable: true })
   previewUrl: string;
 
   @Column()

--- a/src/spotify/spotify.module.ts
+++ b/src/spotify/spotify.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { SpotifyService } from './spotify.service';
+
+@Module({
+  providers: [SpotifyService],
+  exports: [SpotifyService],
+})
+export class SpotifyModule {}

--- a/src/spotify/spotify.service.ts
+++ b/src/spotify/spotify.service.ts
@@ -37,6 +37,7 @@ export class SpotifyService {
   private readonly clientSecret: string;
   private accessToken: string | null = null;
   private expiresAt = 0;
+  private tokenPromise: Promise<string> | null = null;
 
   constructor(private readonly configService: ConfigService) {
     this.clientId = this.configService.get<string>('SPOTIFY_CLIENT_ID')!;
@@ -83,7 +84,17 @@ export class SpotifyService {
     if (this.accessToken && Date.now() < this.expiresAt - 60_000) {
       return this.accessToken;
     }
+    if (this.tokenPromise) {
+      return this.tokenPromise;
+    }
 
+    this.tokenPromise = this.requestToken().finally(() => {
+      this.tokenPromise = null;
+    });
+    return this.tokenPromise;
+  }
+
+  private async requestToken(): Promise<string> {
     const credentials = Buffer.from(
       `${this.clientId}:${this.clientSecret}`,
     ).toString('base64');

--- a/src/spotify/spotify.service.ts
+++ b/src/spotify/spotify.service.ts
@@ -1,0 +1,113 @@
+import {
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface SpotifyTrack {
+  id: string;
+  title: string;
+  artists: string[];
+  albumName: string;
+  albumImageUrl: string | null;
+  spotifyUrl: string | null;
+  previewUrl: string | null;
+  durationMs: number;
+}
+
+interface SpotifySearchResponse {
+  tracks: {
+    items: Array<{
+      id: string;
+      name: string;
+      artists: Array<{ name: string }>;
+      album: { name: string; images?: Array<{ url: string }> };
+      duration_ms?: number;
+      preview_url?: string | null;
+      external_urls?: { spotify?: string };
+    }>;
+  };
+}
+
+@Injectable()
+export class SpotifyService {
+  private readonly logger = new Logger(SpotifyService.name);
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private accessToken: string | null = null;
+  private expiresAt = 0;
+
+  constructor(private readonly configService: ConfigService) {
+    this.clientId = this.configService.get<string>('SPOTIFY_CLIENT_ID')!;
+    this.clientSecret = this.configService.get<string>(
+      'SPOTIFY_CLIENT_SECRET',
+    )!;
+  }
+
+  async searchTracks(keywords: string, limit = 10): Promise<SpotifyTrack[]> {
+    const token = await this.getAccessToken();
+    const query = keywords.trim().replace(/\s+/g, ' ');
+    const params = new URLSearchParams({
+      q: query,
+      type: 'track',
+      limit: String(limit),
+      market: 'KR',
+    });
+
+    const response = await fetch(
+      `https://api.spotify.com/v1/search?${params.toString()}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+
+    if (!response.ok) {
+      this.logger.error(`Spotify search failed: ${response.status}`);
+      throw new ServiceUnavailableException('Spotify search failed');
+    }
+
+    const data = (await response.json()) as SpotifySearchResponse;
+    return data.tracks.items.map((t) => ({
+      id: t.id,
+      title: t.name,
+      artists: t.artists.map((a) => a.name),
+      albumName: t.album.name,
+      albumImageUrl: t.album.images?.[0]?.url ?? null,
+      spotifyUrl:
+        t.external_urls?.spotify ?? `https://open.spotify.com/track/${t.id}`,
+      previewUrl: t.preview_url ?? null,
+      durationMs: t.duration_ms ?? 0,
+    }));
+  }
+
+  private async getAccessToken(): Promise<string> {
+    if (this.accessToken && Date.now() < this.expiresAt - 60_000) {
+      return this.accessToken;
+    }
+
+    const credentials = Buffer.from(
+      `${this.clientId}:${this.clientSecret}`,
+    ).toString('base64');
+
+    const response = await fetch('https://accounts.spotify.com/api/token', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({ grant_type: 'client_credentials' }),
+    });
+
+    if (!response.ok) {
+      this.logger.error(`Spotify auth failed: ${response.status}`);
+      throw new ServiceUnavailableException('Spotify authentication failed');
+    }
+
+    const data = (await response.json()) as {
+      access_token: string;
+      expires_in: number;
+    };
+    this.accessToken = data.access_token;
+    this.expiresAt = Date.now() + data.expires_in * 1000;
+    return this.accessToken;
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- POST /music: 오늘 감정 분석 결과 기반으로 AI 키워드를 추출하고 Spotify에서 곡을 검색해 플레이리스트를 생성/반환
- Spotify 검색 연동 추가 (client credentials 토큰 캐싱 + /search)
- Playlist에 title/imageUrl, Song에 spotifyUrl 컬럼 추가 및 마이그레이션
- EmotionsService에 오늘 최신 감정 조회(findTodayLatest) 추가
- 곡 저장 시 spotifyTrackId 기준 재사용(upsert), 트랜잭션으로 플레이리스트/곡/매핑 일괄 저장

## 💬리뷰 요구사항(선택)

> 기존 Spring 레포의 음악 추천 계약(오늘 감정 → AI 키워드 → Spotify 검색 → 플레이리스트)을 참고했고, 인기도/연도 필터링 등 과한 로직은 제외하고 핵심 흐름만 구현했습니다. memberId 경로 대신 JWT sub를 사용합니다