### PR TITLE
플레이리스트 목록/상세 조회 API 구현

### DIFF
--- a/src/playlists/dto/playlist-list.res.dto.ts
+++ b/src/playlists/dto/playlist-list.res.dto.ts
@@ -19,7 +19,7 @@ export class PlaylistListResDto {
       title: p.title,
       emotion: p.emotionLabel ?? null,
       imageUrl: p.imageUrl ?? null,
-      count: p.playlistSongs?.length ?? 0,
+      count: p.playlistSongsCount ?? 0,
       createdAt: p.createdAt,
     }));
     return dto;

--- a/src/playlists/dto/playlist-list.res.dto.ts
+++ b/src/playlists/dto/playlist-list.res.dto.ts
@@ -1,0 +1,27 @@
+import { Playlist } from '../playlist.entity';
+
+export interface PlaylistSummaryDto {
+  id: string;
+  title: string;
+  emotion: string | null;
+  imageUrl: string | null;
+  count: number;
+  createdAt: Date;
+}
+
+export class PlaylistListResDto {
+  playlists: PlaylistSummaryDto[];
+
+  static from(playlists: Playlist[]): PlaylistListResDto {
+    const dto = new PlaylistListResDto();
+    dto.playlists = playlists.map((p) => ({
+      id: p.id,
+      title: p.title,
+      emotion: p.emotionLabel ?? null,
+      imageUrl: p.imageUrl ?? null,
+      count: p.playlistSongs?.length ?? 0,
+      createdAt: p.createdAt,
+    }));
+    return dto;
+  }
+}

--- a/src/playlists/playlist-song.entity.ts
+++ b/src/playlists/playlist-song.entity.ts
@@ -16,7 +16,9 @@ export class PlaylistSong {
   @Column()
   rank: number;
 
-  @ManyToOne(() => Playlist, (playlist) => playlist.playlistSongs, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Playlist, (playlist) => playlist.playlistSongs, {
+    onDelete: 'CASCADE',
+  })
   playlist: Playlist;
 
   @ManyToOne(() => Song, (song) => song.playlistSongs)

--- a/src/playlists/playlist.entity.ts
+++ b/src/playlists/playlist.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
+  RelationCount,
 } from 'typeorm';
 import { User } from '../users/user.entity';
 import { PlaylistSong } from './playlist-song.entity';
@@ -45,4 +46,7 @@ export class Playlist {
     cascade: true,
   })
   playlistSongs: PlaylistSong[];
+
+  @RelationCount((playlist: Playlist) => playlist.playlistSongs)
+  playlistSongsCount: number;
 }

--- a/src/playlists/playlists.controller.ts
+++ b/src/playlists/playlists.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -26,7 +33,7 @@ export class PlaylistsController {
   @ApiOperation({ summary: '플레이리스트 상세 조회' })
   async findOne(
     @Req() req: Request,
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
   ): Promise<PlaylistResDto> {
     const { sub } = req.user as JwtPayload;
     const playlist = await this.playlistsService.findOneByUserId(sub, id);

--- a/src/playlists/playlists.controller.ts
+++ b/src/playlists/playlists.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { JwtPayload } from '../auth/strategies/jwt.strategy';
+import { PlaylistsService } from './playlists.service';
+import { PlaylistListResDto } from './dto/playlist-list.res.dto';
+import { PlaylistResDto } from './dto/playlist.res.dto';
+
+@ApiTags('playlists')
+@ApiBearerAuth()
+@Controller('playlists')
+@UseGuards(JwtAuthGuard)
+export class PlaylistsController {
+  constructor(private readonly playlistsService: PlaylistsService) {}
+
+  @Get()
+  @ApiOperation({ summary: '내 플레이리스트 목록 조회' })
+  async findAll(@Req() req: Request): Promise<PlaylistListResDto> {
+    const { sub } = req.user as JwtPayload;
+    const playlists = await this.playlistsService.findRecentByUserId(sub);
+    return PlaylistListResDto.from(playlists);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '플레이리스트 상세 조회' })
+  async findOne(
+    @Req() req: Request,
+    @Param('id') id: string,
+  ): Promise<PlaylistResDto> {
+    const { sub } = req.user as JwtPayload;
+    const playlist = await this.playlistsService.findOneByUserId(sub, id);
+    return PlaylistResDto.from(playlist);
+  }
+}

--- a/src/playlists/playlists.module.ts
+++ b/src/playlists/playlists.module.ts
@@ -3,9 +3,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Playlist } from './playlist.entity';
 import { PlaylistSong } from './playlist-song.entity';
 import { PlaylistsService } from './playlists.service';
+import { PlaylistsController } from './playlists.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Playlist, PlaylistSong])],
+  controllers: [PlaylistsController],
   providers: [PlaylistsService],
   exports: [PlaylistsService],
 })

--- a/src/playlists/playlists.service.spec.ts
+++ b/src/playlists/playlists.service.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '../common/exceptions/not-found.exception';
+import { PlaylistsService } from './playlists.service';
+import { Playlist } from './playlist.entity';
+
+describe('PlaylistsService', () => {
+  let service: PlaylistsService;
+  let repository: { find: jest.Mock; findOne: jest.Mock };
+
+  const userId = 'user-1';
+  const playlist = { id: 'pl-1', userId, title: 'Mix' } as Playlist;
+
+  beforeEach(async () => {
+    repository = { find: jest.fn(), findOne: jest.fn() };
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      providers: [
+        PlaylistsService,
+        { provide: getRepositoryToken(Playlist), useValue: repository },
+      ],
+    }).compile();
+    service = moduleRef.get(PlaylistsService);
+  });
+
+  describe('findRecentByUserId', () => {
+    it('returns recent playlists for the user', async () => {
+      repository.find.mockResolvedValue([playlist]);
+      await expect(service.findRecentByUserId(userId)).resolves.toEqual([
+        playlist,
+      ]);
+      expect(repository.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId }, take: 20 }),
+      );
+    });
+  });
+
+  describe('findOneByUserId', () => {
+    it('returns the playlist when owned by the user', async () => {
+      repository.findOne.mockResolvedValue(playlist);
+      await expect(service.findOneByUserId(userId, 'pl-1')).resolves.toEqual(
+        playlist,
+      );
+      expect(repository.findOne).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'pl-1', userId } }),
+      );
+    });
+
+    it('throws NotFoundException when not found or not owned', async () => {
+      repository.findOne.mockResolvedValue(null);
+      await expect(
+        service.findOneByUserId(userId, 'pl-x'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/src/playlists/playlists.service.ts
+++ b/src/playlists/playlists.service.ts
@@ -16,7 +16,6 @@ export class PlaylistsService {
       where: { userId },
       order: { createdAt: 'DESC' },
       take: 20,
-      relations: ['playlistSongs', 'playlistSongs.song'],
     });
   }
 
@@ -24,6 +23,7 @@ export class PlaylistsService {
     const playlist = await this.playlistsRepository.findOne({
       where: { id, userId },
       relations: ['playlistSongs', 'playlistSongs.song'],
+      order: { playlistSongs: { rank: 'ASC' } },
     });
     if (!playlist) {
       throw new NotFoundException('Playlist not found');

--- a/src/playlists/playlists.service.ts
+++ b/src/playlists/playlists.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { NotFoundException } from '../common/exceptions/not-found.exception';
 import { Playlist } from './playlist.entity';
 
 @Injectable()
@@ -17,6 +18,17 @@ export class PlaylistsService {
       take: 20,
       relations: ['playlistSongs', 'playlistSongs.song'],
     });
+  }
+
+  async findOneByUserId(userId: string, id: string): Promise<Playlist> {
+    const playlist = await this.playlistsRepository.findOne({
+      where: { id, userId },
+      relations: ['playlistSongs', 'playlistSongs.song'],
+    });
+    if (!playlist) {
+      throw new NotFoundException('Playlist not found');
+    }
+    return playlist;
   }
 
   create(data: Partial<Playlist>): Promise<Playlist> {


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- GET /playlists: 내 플레이리스트 목록 조회 (id, title, emotion, imageUrl, count, createdAt)
- GET /playlists/:id: 플레이리스트 상세 조회 (곡 목록 포함), 본인 소유만 접근 가능
- PlaylistsController 추가 및 소유권 검증(findOneByUserId, 미존재/타인 소유 시 404)

## 💬리뷰 요구사항(선택)

> 상세 조회는 본인 소유(userId 일치)만 반환하도록 하여 다른 사용자의 플레이리스트 접근을 차단했습니다. 목록은 최근 20개로 제한합니다