### PR TITLE
추천 시 사용자 Spotify 계정에 플레이리스트 생성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,5 @@ AWS_ACCESS_KEY=string
 AWS_SECRET_KEY=string
 AWS_STATIC=string
 AWS_BUCKET=string
+
+ENCRYPTION_KEY=string

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DatabaseModule } from './database/database.module';
+import { CryptoModule } from './common/crypto/crypto.module';
 import { UsersModule } from './users/users.module';
 import { SongsModule } from './songs/songs.module';
 import { PlaylistsModule } from './playlists/playlists.module';
@@ -15,6 +16,7 @@ import { RedisModule } from './redis/redis.module';
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    CryptoModule,
     DatabaseModule,
     RedisModule,
     UsersModule,

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -6,6 +6,7 @@ import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { RedisService } from '../redis/redis.service';
 import { PreferencesService } from '../preferences/preferences.service';
+import { CryptoService } from '../common/crypto/crypto.service';
 import { UnauthorizedException } from '../common/exceptions/unauthorized.exception';
 
 function jsonResponse(ok: boolean, body: unknown): Response {
@@ -22,9 +23,14 @@ const CONFIG: Record<string, string> = {
 describe('AuthService', () => {
   let service: AuthService;
   let jwt: { sign: jest.Mock; verify: jest.Mock };
-  let usersService: { findBySpotifyId: jest.Mock; create: jest.Mock };
+  let usersService: {
+    findBySpotifyId: jest.Mock;
+    create: jest.Mock;
+    updateSpotifyRefreshToken: jest.Mock;
+  };
   let redisService: { get: jest.Mock; set: jest.Mock; del: jest.Mock };
   let preferencesService: { existsByUserId: jest.Mock };
+  let cryptoService: { encrypt: jest.Mock; decrypt: jest.Mock };
   let configService: { get: jest.Mock };
   let fetchMock: jest.SpyInstance;
 
@@ -32,7 +38,12 @@ describe('AuthService', () => {
 
   function mockSpotifySuccess() {
     fetchMock
-      .mockResolvedValueOnce(jsonResponse(true, { access_token: 'sp-access' }))
+      .mockResolvedValueOnce(
+        jsonResponse(true, {
+          access_token: 'sp-access',
+          refresh_token: 'sp-refresh',
+        }),
+      )
       .mockResolvedValueOnce(
         jsonResponse(true, {
           id: 'sp-1',
@@ -45,9 +56,17 @@ describe('AuthService', () => {
 
   beforeEach(async () => {
     jwt = { sign: jest.fn().mockReturnValue('token'), verify: jest.fn() };
-    usersService = { findBySpotifyId: jest.fn(), create: jest.fn() };
+    usersService = {
+      findBySpotifyId: jest.fn(),
+      create: jest.fn(),
+      updateSpotifyRefreshToken: jest.fn(),
+    };
     redisService = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
     preferencesService = { existsByUserId: jest.fn() };
+    cryptoService = {
+      encrypt: jest.fn((v: string) => `enc(${v})`),
+      decrypt: jest.fn(),
+    };
     configService = { get: jest.fn((key: string) => CONFIG[key]) };
 
     const moduleRef: TestingModule = await Test.createTestingModule({
@@ -58,6 +77,7 @@ describe('AuthService', () => {
         { provide: UsersService, useValue: usersService },
         { provide: RedisService, useValue: redisService },
         { provide: PreferencesService, useValue: preferencesService },
+        { provide: CryptoService, useValue: cryptoService },
       ],
     }).compile();
 
@@ -87,6 +107,11 @@ describe('AuthService', () => {
         'refresh:user-1',
         'hashed',
         expect.any(Number),
+      );
+      expect(cryptoService.encrypt).toHaveBeenCalledWith('sp-refresh');
+      expect(usersService.updateSpotifyRefreshToken).toHaveBeenCalledWith(
+        'user-1',
+        'enc(sp-refresh)',
       );
       expect(res.accessToken).toBe('token');
       expect(res.onboarded).toBe(false);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import { UnauthorizedException } from '../common/exceptions/unauthorized.excepti
 import { RedisService } from '../redis/redis.service';
 import { UsersService } from '../users/users.service';
 import { PreferencesService } from '../preferences/preferences.service';
+import { CryptoService } from '../common/crypto/crypto.service';
 import { JwtPayload } from './strategies/jwt.strategy';
 import { TokenResDto } from './dto/token.res.dto';
 
@@ -34,6 +35,7 @@ export class AuthService {
     private readonly usersService: UsersService,
     private readonly redisService: RedisService,
     private readonly preferencesService: PreferencesService,
+    private readonly cryptoService: CryptoService,
   ) {}
 
   async loginWithCode(code: string): Promise<TokenResDto> {
@@ -48,6 +50,13 @@ export class AuthService {
         displayName: profile.display_name,
         profileImageUrl: profile.images?.[0]?.url ?? null,
       });
+    }
+
+    if (spotifyTokens.refresh_token) {
+      await this.usersService.updateSpotifyRefreshToken(
+        user.id,
+        this.cryptoService.encrypt(spotifyTokens.refresh_token),
+      );
     }
 
     return this.issueTokens(user.id, user.email);

--- a/src/common/crypto/crypto.module.ts
+++ b/src/common/crypto/crypto.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { CryptoService } from './crypto.service';
+
+@Global()
+@Module({
+  providers: [CryptoService],
+  exports: [CryptoService],
+})
+export class CryptoModule {}

--- a/src/common/crypto/crypto.service.spec.ts
+++ b/src/common/crypto/crypto.service.spec.ts
@@ -1,0 +1,41 @@
+import { ConfigService } from '@nestjs/config';
+import { CryptoService } from './crypto.service';
+
+describe('CryptoService', () => {
+  let service: CryptoService;
+
+  beforeEach(() => {
+    const configService = {
+      get: jest.fn(() => 'test-encryption-secret'),
+    } as unknown as ConfigService;
+    service = new CryptoService(configService);
+  });
+
+  it('decrypts what it encrypts (round-trip)', () => {
+    const plain = 'spotify-refresh-token-abc123';
+    const encrypted = service.encrypt(plain);
+
+    expect(encrypted).not.toContain(plain);
+    expect(service.decrypt(encrypted)).toBe(plain);
+  });
+
+  it('produces different ciphertext for the same input (random IV)', () => {
+    const a = service.encrypt('same');
+    const b = service.encrypt('same');
+    expect(a).not.toBe(b);
+    expect(service.decrypt(a)).toBe('same');
+    expect(service.decrypt(b)).toBe('same');
+  });
+
+  it('throws when the ciphertext is tampered', () => {
+    const encrypted = service.encrypt('secret');
+    const [iv, tag, data] = encrypted.split(':');
+    const tampered = [iv, tag, Buffer.from('zzzz').toString('base64')].join(
+      ':',
+    );
+    expect(() =>
+      service.decrypt(`${iv}:${tag}:${tampered.split(':')[2]}`),
+    ).toThrow();
+    expect(data).toBeDefined();
+  });
+});

--- a/src/common/crypto/crypto.service.ts
+++ b/src/common/crypto/crypto.service.ts
@@ -1,0 +1,48 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  scryptSync,
+} from 'crypto';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+
+@Injectable()
+export class CryptoService {
+  private readonly key: Buffer;
+
+  constructor(private readonly configService: ConfigService) {
+    const secret = this.configService.get<string>('ENCRYPTION_KEY')!;
+    this.key = scryptSync(secret, 'nochu-crypto', 32);
+  }
+
+  encrypt(plainText: string): string {
+    const iv = randomBytes(IV_LENGTH);
+    const cipher = createCipheriv(ALGORITHM, this.key, iv);
+    const encrypted = Buffer.concat([
+      cipher.update(plainText, 'utf8'),
+      cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+    return [
+      iv.toString('base64'),
+      tag.toString('base64'),
+      encrypted.toString('base64'),
+    ].join(':');
+  }
+
+  decrypt(cipherText: string): string {
+    const [ivB64, tagB64, dataB64] = cipherText.split(':');
+    const iv = Buffer.from(ivB64, 'base64');
+    const tag = Buffer.from(tagB64, 'base64');
+    const data = Buffer.from(dataB64, 'base64');
+    const decipher = createDecipheriv(ALGORITHM, this.key, iv);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(data), decipher.final()]).toString(
+      'utf8',
+    );
+  }
+}

--- a/src/database/migrations/1783645046585-SpotifyExport.ts
+++ b/src/database/migrations/1783645046585-SpotifyExport.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SpotifyExport1783645046585 implements MigrationInterface {
+  name = 'SpotifyExport1783645046585';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "playlists" ADD "spotifyPlaylistId" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "playlists" ADD "spotifyPlaylistUrl" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "spotifyRefreshToken" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN "spotifyRefreshToken"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "playlists" DROP COLUMN "spotifyPlaylistUrl"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "playlists" DROP COLUMN "spotifyPlaylistId"`,
+    );
+  }
+}

--- a/src/music/music.module.ts
+++ b/src/music/music.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { AiModule } from '../ai/ai.module';
 import { EmotionsModule } from '../emotions/emotions.module';
 import { SpotifyModule } from '../spotify/spotify.module';
+import { UsersModule } from '../users/users.module';
 import { MusicController } from './music.controller';
 import { MusicService } from './music.service';
 
 @Module({
-  imports: [EmotionsModule, AiModule, SpotifyModule],
+  imports: [EmotionsModule, AiModule, SpotifyModule, UsersModule],
   controllers: [MusicController],
   providers: [MusicService],
 })

--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -5,6 +5,8 @@ import { MusicService } from './music.service';
 import { EmotionsService } from '../emotions/emotions.service';
 import { AiService } from '../ai/ai.service';
 import { SpotifyService } from '../spotify/spotify.service';
+import { UsersService } from '../users/users.service';
+import { CryptoService } from '../common/crypto/crypto.service';
 import { Emotion } from '../emotions/emotion.entity';
 import { Playlist } from '../playlists/playlist.entity';
 
@@ -12,7 +14,9 @@ describe('MusicService', () => {
   let service: MusicService;
   let emotionsService: { findTodayLatest: jest.Mock };
   let aiService: { extractKeywords: jest.Mock };
-  let spotifyService: { searchTracks: jest.Mock };
+  let spotifyService: { searchTracks: jest.Mock; createPlaylist: jest.Mock };
+  let usersService: { findOne: jest.Mock };
+  let cryptoService: { decrypt: jest.Mock };
 
   const userId = 'user-1';
   const emotion = {
@@ -70,13 +74,19 @@ describe('MusicService', () => {
     findOneOrFail: jest.fn().mockResolvedValue(savedPlaylist),
   };
 
+  const playlistRepo = { update: jest.fn().mockResolvedValue(undefined) };
+
   beforeEach(async () => {
     emotionsService = { findTodayLatest: jest.fn() };
     aiService = { extractKeywords: jest.fn() };
-    spotifyService = { searchTracks: jest.fn() };
+    spotifyService = { searchTracks: jest.fn(), createPlaylist: jest.fn() };
+    usersService = { findOne: jest.fn().mockResolvedValue(null) };
+    cryptoService = { decrypt: jest.fn((v: string) => `dec(${v})`) };
+    playlistRepo.update.mockClear();
 
     const dataSource = {
       transaction: jest.fn((cb: (m: typeof manager) => unknown) => cb(manager)),
+      getRepository: jest.fn(() => playlistRepo),
     };
 
     const moduleRef: TestingModule = await Test.createTestingModule({
@@ -86,6 +96,8 @@ describe('MusicService', () => {
         { provide: EmotionsService, useValue: emotionsService },
         { provide: AiService, useValue: aiService },
         { provide: SpotifyService, useValue: spotifyService },
+        { provide: UsersService, useValue: usersService },
+        { provide: CryptoService, useValue: cryptoService },
       ],
     }).compile();
 
@@ -130,5 +142,56 @@ describe('MusicService', () => {
     await expect(service.recommend(userId, null)).rejects.toBeInstanceOf(
       NotFoundException,
     );
+  });
+
+  it('exports to Spotify when the user has a refresh token', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    aiService.extractKeywords.mockResolvedValue({
+      keywords: 'happy',
+      title: 'Happy Mix',
+    });
+    spotifyService.searchTracks.mockResolvedValue([track]);
+    usersService.findOne.mockResolvedValue({
+      spotifyId: 'sp-user',
+      spotifyRefreshToken: 'enc-token',
+    });
+    spotifyService.createPlaylist.mockResolvedValue({
+      id: 'sp-pl',
+      url: 'https://open.spotify.com/playlist/sp-pl',
+    });
+
+    await service.recommend(userId, null);
+
+    expect(cryptoService.decrypt).toHaveBeenCalledWith('enc-token');
+    expect(spotifyService.createPlaylist).toHaveBeenCalledWith(
+      'dec(enc-token)',
+      'sp-user',
+      'Happy Mix',
+      ['track-1'],
+    );
+    expect(playlistRepo.update).toHaveBeenCalledWith(
+      'pl-1',
+      expect.objectContaining({
+        spotifyPlaylistUrl: 'https://open.spotify.com/playlist/sp-pl',
+      }),
+    );
+  });
+
+  it('still succeeds when Spotify export fails (best-effort)', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    aiService.extractKeywords.mockResolvedValue({
+      keywords: 'happy',
+      title: 'Mix',
+    });
+    spotifyService.searchTracks.mockResolvedValue([track]);
+    usersService.findOne.mockResolvedValue({
+      spotifyId: 'sp-user',
+      spotifyRefreshToken: 'enc-token',
+    });
+    spotifyService.createPlaylist.mockRejectedValue(new Error('spotify down'));
+
+    const result = await service.recommend(userId, null);
+    expect(result.id).toBe('pl-1');
+    expect(playlistRepo.update).not.toHaveBeenCalled();
   });
 });

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -1,9 +1,11 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource, In } from 'typeorm';
 import { EmotionsService } from '../emotions/emotions.service';
 import { AiService } from '../ai/ai.service';
 import { SpotifyService, SpotifyTrack } from '../spotify/spotify.service';
+import { UsersService } from '../users/users.service';
+import { CryptoService } from '../common/crypto/crypto.service';
 import { Playlist } from '../playlists/playlist.entity';
 import { PlaylistSong } from '../playlists/playlist-song.entity';
 import { Song } from '../songs/song.entity';
@@ -11,12 +13,16 @@ import { PlaylistResDto } from '../playlists/dto/playlist.res.dto';
 
 @Injectable()
 export class MusicService {
+  private readonly logger = new Logger(MusicService.name);
+
   constructor(
     @InjectDataSource()
     private readonly dataSource: DataSource,
     private readonly emotionsService: EmotionsService,
     private readonly aiService: AiService,
     private readonly spotifyService: SpotifyService,
+    private readonly usersService: UsersService,
+    private readonly cryptoService: CryptoService,
   ) {}
 
   async recommend(
@@ -42,7 +48,42 @@ export class MusicService {
     }
 
     const playlist = await this.save(userId, emotion.emotion, title, tracks);
+    await this.exportToSpotify(userId, playlist, title, tracks);
     return PlaylistResDto.from(playlist);
+  }
+
+  private async exportToSpotify(
+    userId: string,
+    playlist: Playlist,
+    title: string,
+    tracks: SpotifyTrack[],
+  ): Promise<void> {
+    try {
+      const user = await this.usersService.findOne(userId);
+      if (!user?.spotifyRefreshToken) {
+        return;
+      }
+
+      const refreshToken = this.cryptoService.decrypt(user.spotifyRefreshToken);
+      const created = await this.spotifyService.createPlaylist(
+        refreshToken,
+        user.spotifyId,
+        title,
+        tracks.map((t) => t.id),
+      );
+
+      playlist.spotifyPlaylistId = created.id;
+      playlist.spotifyPlaylistUrl = created.url ?? null;
+      await this.dataSource.getRepository(Playlist).update(playlist.id, {
+        spotifyPlaylistId: created.id,
+        spotifyPlaylistUrl: created.url,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Spotify playlist export failed for user ${userId}`,
+        error as Error,
+      );
+    }
   }
 
   private save(

--- a/src/playlists/dto/playlist.res.dto.ts
+++ b/src/playlists/dto/playlist.res.dto.ts
@@ -28,6 +28,7 @@ export class PlaylistResDto {
   id: string;
   title: string;
   imageUrl: string | null;
+  spotifyPlaylistUrl: string | null;
   tracks: PlaylistTrackDto[];
 
   static from(playlist: Playlist): PlaylistResDto {
@@ -35,6 +36,7 @@ export class PlaylistResDto {
     dto.id = playlist.id;
     dto.title = playlist.title;
     dto.imageUrl = playlist.imageUrl ?? null;
+    dto.spotifyPlaylistUrl = playlist.spotifyPlaylistUrl ?? null;
     dto.tracks = [...(playlist.playlistSongs ?? [])]
       .sort((a, b) => a.rank - b.rank)
       .map((ps) => ({

--- a/src/playlists/playlist.entity.ts
+++ b/src/playlists/playlist.entity.ts
@@ -24,6 +24,12 @@ export class Playlist {
   @Column({ nullable: true })
   imageUrl: string;
 
+  @Column({ type: 'varchar', nullable: true })
+  spotifyPlaylistId: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  spotifyPlaylistUrl: string | null;
+
   @Column({ nullable: true })
   emotionLabel: string;
 

--- a/src/spotify/spotify.service.ts
+++ b/src/spotify/spotify.service.ts
@@ -143,12 +143,12 @@ export class SpotifyService {
       body: JSON.stringify({ name, public: false }),
     });
 
-    if (trackIds.length > 0) {
+    const uris = trackIds.map((id) => `spotify:track:${id}`);
+    const CHUNK_SIZE = 100;
+    for (let i = 0; i < uris.length; i += CHUNK_SIZE) {
       await this.userFetch(token, `/v1/playlists/${created.id}/tracks`, {
         method: 'POST',
-        body: JSON.stringify({
-          uris: trackIds.map((id) => `spotify:track:${id}`),
-        }),
+        body: JSON.stringify({ uris: uris.slice(i, i + CHUNK_SIZE) }),
       });
     }
 
@@ -173,8 +173,9 @@ export class SpotifyService {
     });
 
     if (!response.ok) {
+      const body = await response.text().catch(() => '');
       this.logger.error(
-        `Spotify user token refresh failed: ${response.status}`,
+        `Spotify user token refresh failed: ${response.status} ${body}`,
       );
       throw new ServiceUnavailableException('Spotify token refresh failed');
     }
@@ -197,7 +198,8 @@ export class SpotifyService {
     });
 
     if (!response.ok) {
-      this.logger.error(`Spotify ${path} failed: ${response.status}`);
+      const body = await response.text().catch(() => '');
+      this.logger.error(`Spotify ${path} failed: ${response.status} ${body}`);
       throw new ServiceUnavailableException('Spotify API request failed');
     }
 

--- a/src/spotify/spotify.service.ts
+++ b/src/spotify/spotify.service.ts
@@ -16,6 +16,11 @@ export interface SpotifyTrack {
   durationMs: number;
 }
 
+export interface CreatedSpotifyPlaylist {
+  id: string;
+  url: string | null;
+}
+
 interface SpotifySearchResponse {
   tracks: {
     items: Array<{
@@ -120,5 +125,82 @@ export class SpotifyService {
     this.accessToken = data.access_token;
     this.expiresAt = Date.now() + data.expires_in * 1000;
     return this.accessToken;
+  }
+
+  async createPlaylist(
+    refreshToken: string,
+    spotifyUserId: string,
+    name: string,
+    trackIds: string[],
+  ): Promise<CreatedSpotifyPlaylist> {
+    const token = await this.refreshUserToken(refreshToken);
+
+    const created = await this.userFetch<{
+      id: string;
+      external_urls?: { spotify?: string };
+    }>(token, `/v1/users/${spotifyUserId}/playlists`, {
+      method: 'POST',
+      body: JSON.stringify({ name, public: false }),
+    });
+
+    if (trackIds.length > 0) {
+      await this.userFetch(token, `/v1/playlists/${created.id}/tracks`, {
+        method: 'POST',
+        body: JSON.stringify({
+          uris: trackIds.map((id) => `spotify:track:${id}`),
+        }),
+      });
+    }
+
+    return { id: created.id, url: created.external_urls?.spotify ?? null };
+  }
+
+  private async refreshUserToken(refreshToken: string): Promise<string> {
+    const credentials = Buffer.from(
+      `${this.clientId}:${this.clientSecret}`,
+    ).toString('base64');
+
+    const response = await fetch('https://accounts.spotify.com/api/token', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      }),
+    });
+
+    if (!response.ok) {
+      this.logger.error(
+        `Spotify user token refresh failed: ${response.status}`,
+      );
+      throw new ServiceUnavailableException('Spotify token refresh failed');
+    }
+
+    const data = (await response.json()) as { access_token: string };
+    return data.access_token;
+  }
+
+  private async userFetch<T>(
+    token: string,
+    path: string,
+    init: RequestInit,
+  ): Promise<T> {
+    const response = await fetch(`https://api.spotify.com${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      this.logger.error(`Spotify ${path} failed: ${response.status}`);
+      throw new ServiceUnavailableException('Spotify API request failed');
+    }
+
+    return (await response.json()) as T;
   }
 }

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -27,6 +27,9 @@ export class User {
   @Column({ nullable: true })
   profileImageUrl: string;
 
+  @Column({ type: 'text', nullable: true })
+  spotifyRefreshToken: string | null;
+
   @CreateDateColumn()
   createdAt: Date;
 
@@ -36,6 +39,8 @@ export class User {
   @OneToMany(() => Playlist, (playlist) => playlist.user, { cascade: true })
   playlists: Playlist[];
 
-  @OneToOne(() => UserPreference, (preference) => preference.user, { cascade: true })
+  @OneToOne(() => UserPreference, (preference) => preference.user, {
+    cascade: true,
+  })
   preference: UserPreference;
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -22,4 +22,13 @@ export class UsersService {
     const user = this.usersRepository.create(data);
     return this.usersRepository.save(user);
   }
+
+  async updateSpotifyRefreshToken(
+    userId: string,
+    encryptedToken: string,
+  ): Promise<void> {
+    await this.usersRepository.update(userId, {
+      spotifyRefreshToken: encryptedToken,
+    });
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- 추천 생성(POST /music) 시 사용자의 실제 Spotify 계정에 플레이리스트를 자동 생성
- 로그인 시 버려지던 Spotify refresh token을 AES-256-GCM으로 암호화해 users 테이블에 저장
- SpotifyService에 사용자 토큰 재발급 + 플레이리스트 생성/트랙 추가 API 추가
- best-effort 설계: Spotify 생성 실패(스코프 없음/토큰 만료/장애)해도 추천 응답은 정상 반환(spotifyPlaylistUrl=null)
- Playlist 응답에 spotifyPlaylistUrl 추가, 관련 컬럼 마이그레이션

## 💬리뷰 요구사항(선택)

> refresh token은 평문 저장/로깅하지 않고 AES-256-GCM 암호화(키는 ENCRYPTION_KEY 환경변수). playlist-modify 스코프는 클라이언트가 authorization URL 생성 시 추가해야 하며(프론트 협업), 스코프 없이 로그인한 유저는 best-effort로 조용히 스킵됩니다. ENCRYPTION_KEY는 APP_ENV 시크릿에 추가 완료했습니다