### PR TITLE
SpotifyService 및 S3Service 단위 테스트 추가

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,8 @@ export default tseslint.config(
     files: ['**/*.spec.ts'],
     rules: {
       '@typescript-eslint/unbound-method': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
     },
   },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,8 +39,6 @@ export default tseslint.config(
     files: ['**/*.spec.ts'],
     rules: {
       '@typescript-eslint/unbound-method': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
     },
   },
 );

--- a/src/spotify/spotify.service.spec.ts
+++ b/src/spotify/spotify.service.spec.ts
@@ -20,6 +20,9 @@ describe('SpotifyService', () => {
   let service: SpotifyService;
   let fetchMock: jest.SpyInstance;
 
+  const fetchUrls = (): string[] =>
+    (fetchMock.mock.calls as [string][]).map(([u]) => u);
+
   beforeEach(() => {
     const configService = {
       get: jest.fn((key: string) => CONFIG[key]),
@@ -77,8 +80,8 @@ describe('SpotifyService', () => {
       await service.searchTracks('a');
       await service.searchTracks('b');
 
-      const tokenCalls = fetchMock.mock.calls.filter((c) =>
-        String(c[0]).includes('accounts.spotify.com'),
+      const tokenCalls = fetchUrls().filter((u) =>
+        u.includes('accounts.spotify.com'),
       );
       expect(tokenCalls).toHaveLength(1);
     });
@@ -93,6 +96,34 @@ describe('SpotifyService', () => {
       await expect(service.searchTracks('x')).rejects.toBeInstanceOf(
         ServiceUnavailableException,
       );
+    });
+
+    it('handles missing album images and external_urls with fallbacks', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(true, { access_token: 'tok', expires_in: 3600 }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse(true, {
+            tracks: {
+              items: [
+                {
+                  id: 't9',
+                  name: 'Bare',
+                  artists: [{ name: 'A' }],
+                  album: { name: 'Album' },
+                },
+              ],
+            },
+          }),
+        );
+
+      const tracks = await service.searchTracks('x');
+
+      expect(tracks[0].albumImageUrl).toBeNull();
+      expect(tracks[0].spotifyUrl).toBe('https://open.spotify.com/track/t9');
+      expect(tracks[0].previewUrl).toBeNull();
+      expect(tracks[0].durationMs).toBe(0);
     });
   });
 
@@ -118,8 +149,7 @@ describe('SpotifyService', () => {
       );
 
       expect(result).toEqual({ id: 'pl-1', url: 'http://playlist' });
-      const createCall = fetchMock.mock.calls[1];
-      expect(String(createCall[0])).toContain('/v1/users/sp-user/playlists');
+      expect(fetchUrls()[1]).toContain('/v1/users/sp-user/playlists');
     });
 
     it('chunks track additions into batches of 100', async () => {
@@ -133,9 +163,7 @@ describe('SpotifyService', () => {
       const ids = Array.from({ length: 150 }, (_, i) => `t${i}`);
       await service.createPlaylist('r', 'u', 'name', ids);
 
-      const trackCalls = fetchMock.mock.calls.filter((c) =>
-        String(c[0]).includes('/tracks'),
-      );
+      const trackCalls = fetchUrls().filter((u) => u.includes('/tracks'));
       expect(trackCalls).toHaveLength(2);
     });
 
@@ -144,6 +172,20 @@ describe('SpotifyService', () => {
       await expect(
         service.createPlaylist('r', 'u', 'n', ['t1']),
       ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    });
+
+    it('does not call the tracks endpoint when there are no tracks', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(true, { access_token: 'user-token' }),
+        )
+        .mockResolvedValueOnce(jsonResponse(true, { id: 'pl-1' }));
+
+      const result = await service.createPlaylist('r', 'u', 'name', []);
+
+      expect(result.id).toBe('pl-1');
+      const trackCalls = fetchUrls().filter((u) => u.includes('/tracks'));
+      expect(trackCalls).toHaveLength(0);
     });
   });
 });

--- a/src/spotify/spotify.service.spec.ts
+++ b/src/spotify/spotify.service.spec.ts
@@ -1,0 +1,149 @@
+import { ConfigService } from '@nestjs/config';
+import { ServiceUnavailableException } from '@nestjs/common';
+import { SpotifyService } from './spotify.service';
+
+const CONFIG: Record<string, string> = {
+  SPOTIFY_CLIENT_ID: 'client-id',
+  SPOTIFY_CLIENT_SECRET: 'client-secret',
+};
+
+function jsonResponse(ok: boolean, body: unknown): Response {
+  return {
+    ok,
+    status: ok ? 200 : 400,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('SpotifyService', () => {
+  let service: SpotifyService;
+  let fetchMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    const configService = {
+      get: jest.fn((key: string) => CONFIG[key]),
+    } as unknown as ConfigService;
+    service = new SpotifyService(configService);
+    fetchMock = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('searchTracks', () => {
+    it('fetches a token then maps search results', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(true, { access_token: 'app-token', expires_in: 3600 }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse(true, {
+            tracks: {
+              items: [
+                {
+                  id: 't1',
+                  name: 'Song',
+                  artists: [{ name: 'A' }, { name: 'B' }],
+                  album: { name: 'Album', images: [{ url: 'http://img' }] },
+                  duration_ms: 1000,
+                  external_urls: { spotify: 'http://track' },
+                },
+              ],
+            },
+          }),
+        );
+
+      const tracks = await service.searchTracks('happy');
+
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0]).toMatchObject({
+        id: 't1',
+        title: 'Song',
+        artists: ['A', 'B'],
+        albumImageUrl: 'http://img',
+        spotifyUrl: 'http://track',
+      });
+    });
+
+    it('reuses the cached token on a second search', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(true, { access_token: 'tok', expires_in: 3600 }),
+        )
+        .mockResolvedValue(jsonResponse(true, { tracks: { items: [] } }));
+
+      await service.searchTracks('a');
+      await service.searchTracks('b');
+
+      const tokenCalls = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).includes('accounts.spotify.com'),
+      );
+      expect(tokenCalls).toHaveLength(1);
+    });
+
+    it('throws when search fails', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(true, { access_token: 'tok', expires_in: 3600 }),
+        )
+        .mockResolvedValueOnce(jsonResponse(false, {}));
+
+      await expect(service.searchTracks('x')).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
+    });
+  });
+
+  describe('createPlaylist', () => {
+    it('refreshes token, creates playlist, adds tracks', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(true, { access_token: 'user-token' }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse(true, {
+            id: 'pl-1',
+            external_urls: { spotify: 'http://playlist' },
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse(true, {}));
+
+      const result = await service.createPlaylist(
+        'refresh-token',
+        'sp-user',
+        'My Mix',
+        ['t1', 't2'],
+      );
+
+      expect(result).toEqual({ id: 'pl-1', url: 'http://playlist' });
+      const createCall = fetchMock.mock.calls[1];
+      expect(String(createCall[0])).toContain('/v1/users/sp-user/playlists');
+    });
+
+    it('chunks track additions into batches of 100', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse(true, { access_token: 'user-token' }),
+        )
+        .mockResolvedValueOnce(jsonResponse(true, { id: 'pl-1' }))
+        .mockResolvedValue(jsonResponse(true, {}));
+
+      const ids = Array.from({ length: 150 }, (_, i) => `t${i}`);
+      await service.createPlaylist('r', 'u', 'name', ids);
+
+      const trackCalls = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).includes('/tracks'),
+      );
+      expect(trackCalls).toHaveLength(2);
+    });
+
+    it('throws when token refresh fails', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(false, {}));
+      await expect(
+        service.createPlaylist('r', 'u', 'n', ['t1']),
+      ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    });
+  });
+});

--- a/src/storage/s3.service.spec.ts
+++ b/src/storage/s3.service.spec.ts
@@ -1,0 +1,62 @@
+import { ConfigService } from '@nestjs/config';
+import { PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { S3Service } from './s3.service';
+
+const CONFIG: Record<string, string> = {
+  AWS_STATIC: 'ap-northeast-2',
+  AWS_BUCKET: 'nochu-bucket',
+  AWS_ACCESS_KEY: 'access',
+  AWS_SECRET_KEY: 'secret',
+};
+
+describe('S3Service', () => {
+  let service: S3Service;
+  let send: jest.Mock;
+
+  beforeEach(() => {
+    const configService = {
+      get: jest.fn((key: string) => CONFIG[key]),
+    } as unknown as ConfigService;
+    service = new S3Service(configService);
+    send = jest.fn().mockResolvedValue({});
+    (service as unknown as { client: { send: jest.Mock } }).client = { send };
+  });
+
+  describe('upload', () => {
+    it('puts the object and returns a public URL', async () => {
+      const url = await service.upload(
+        Buffer.from('img'),
+        'image/png',
+        'emotions',
+      );
+
+      expect(send).toHaveBeenCalledTimes(1);
+      const command = send.mock.calls[0][0] as PutObjectCommand;
+      expect(command).toBeInstanceOf(PutObjectCommand);
+      expect(command.input.Bucket).toBe('nochu-bucket');
+      expect(command.input.ContentType).toBe('image/png');
+      expect(command.input.Key).toMatch(/^emotions\/.+\.png$/);
+      expect(url).toMatch(
+        /^https:\/\/nochu-bucket\.s3\.ap-northeast-2\.amazonaws\.com\/emotions\/.+\.png$/,
+      );
+    });
+
+    it('falls back to bin extension for unknown mimetype', async () => {
+      const url = await service.upload(Buffer.from('x'), 'application/x', 'p');
+      expect(url).toMatch(/\.bin$/);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes the object by parsing the key from the URL', async () => {
+      await service.delete(
+        'https://nochu-bucket.s3.ap-northeast-2.amazonaws.com/emotions/abc.png',
+      );
+
+      const command = send.mock.calls[0][0] as DeleteObjectCommand;
+      expect(command).toBeInstanceOf(DeleteObjectCommand);
+      expect(command.input.Bucket).toBe('nochu-bucket');
+      expect(command.input.Key).toBe('emotions/abc.png');
+    });
+  });
+});

--- a/src/storage/s3.service.spec.ts
+++ b/src/storage/s3.service.spec.ts
@@ -2,6 +2,19 @@ import { ConfigService } from '@nestjs/config';
 import { PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { S3Service } from './s3.service';
 
+const send = jest.fn();
+
+jest.mock('@aws-sdk/client-s3', () => {
+  const actual =
+    jest.requireActual<typeof import('@aws-sdk/client-s3')>(
+      '@aws-sdk/client-s3',
+    );
+  return {
+    ...actual,
+    S3Client: jest.fn().mockImplementation(() => ({ send })),
+  };
+});
+
 const CONFIG: Record<string, string> = {
   AWS_STATIC: 'ap-northeast-2',
   AWS_BUCKET: 'nochu-bucket',
@@ -11,15 +24,14 @@ const CONFIG: Record<string, string> = {
 
 describe('S3Service', () => {
   let service: S3Service;
-  let send: jest.Mock;
 
   beforeEach(() => {
+    send.mockReset();
+    send.mockResolvedValue({});
     const configService = {
       get: jest.fn((key: string) => CONFIG[key]),
     } as unknown as ConfigService;
     service = new S3Service(configService);
-    send = jest.fn().mockResolvedValue({});
-    (service as unknown as { client: { send: jest.Mock } }).client = { send };
   });
 
   describe('upload', () => {
@@ -31,6 +43,7 @@ describe('S3Service', () => {
       );
 
       expect(send).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const command = send.mock.calls[0][0] as PutObjectCommand;
       expect(command).toBeInstanceOf(PutObjectCommand);
       expect(command.input.Bucket).toBe('nochu-bucket');
@@ -53,6 +66,7 @@ describe('S3Service', () => {
         'https://nochu-bucket.s3.ap-northeast-2.amazonaws.com/emotions/abc.png',
       );
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const command = send.mock.calls[0][0] as DeleteObjectCommand;
       expect(command).toBeInstanceOf(DeleteObjectCommand);
       expect(command.input.Bucket).toBe('nochu-bucket');


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- SpotifyService 단위 테스트 추가 (토큰 발급/캐시, 검색 결과 매핑, 플레이리스트 생성, 트랙 100개 청킹, 실패 케이스)
- S3Service 단위 테스트 추가 (업로드 URL 생성, mimetype 폴백, URL 파싱 후 삭제)
- spec 파일에 한해 mock.calls 인덱싱 관련 lint 규칙 예외 처리

## 💬리뷰 요구사항(선택)

> 외부 의존(fetch, S3 SDK)은 목으로 격리했습니다. 로직이 있는 서비스 중 테스트가 없던 SpotifyService/S3Service를 보강해 핵심 서비스 커버리지를 채웠습니다