### PR TITLE
음악 추천 성능 개선 (캐시·인덱스·비동기 export)

### DIFF
--- a/src/database/migrations/1783649765433-PlaylistUserIndex.ts
+++ b/src/database/migrations/1783649765433-PlaylistUserIndex.ts
@@ -10,8 +10,6 @@ export class PlaylistUserIndex1783649765433 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `DROP INDEX "public"."IDX_c298a5f2f65603b1a8519e3e26"`,
-    );
+    await queryRunner.query(`DROP INDEX "IDX_c298a5f2f65603b1a8519e3e26"`);
   }
 }

--- a/src/database/migrations/1783649765433-PlaylistUserIndex.ts
+++ b/src/database/migrations/1783649765433-PlaylistUserIndex.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PlaylistUserIndex1783649765433 implements MigrationInterface {
+  name = 'PlaylistUserIndex1783649765433';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c298a5f2f65603b1a8519e3e26" ON "playlists" ("userId", "createdAt") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c298a5f2f65603b1a8519e3e26"`,
+    );
+  }
+}

--- a/src/music/music.module.ts
+++ b/src/music/music.module.ts
@@ -4,6 +4,7 @@ import { EmotionsModule } from '../emotions/emotions.module';
 import { SpotifyModule } from '../spotify/spotify.module';
 import { UsersModule } from '../users/users.module';
 import { PreferencesModule } from '../preferences/preferences.module';
+import { RedisModule } from '../redis/redis.module';
 import { MusicController } from './music.controller';
 import { MusicService } from './music.service';
 
@@ -14,6 +15,7 @@ import { MusicService } from './music.service';
     SpotifyModule,
     UsersModule,
     PreferencesModule,
+    RedisModule,
   ],
   controllers: [MusicController],
   providers: [MusicService],

--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -252,4 +252,19 @@ describe('MusicService', () => {
       expect.any(Number),
     );
   });
+
+  it('falls back to AI when the cache read fails', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    aiService.extractKeywords.mockResolvedValue({
+      keywords: 'fresh',
+      title: 'Fresh Mix',
+    });
+    spotifyService.searchTracks.mockResolvedValue([track]);
+    redisService.get.mockRejectedValue(new Error('redis down'));
+
+    const result = await service.recommend(userId);
+
+    expect(aiService.extractKeywords).toHaveBeenCalled();
+    expect(result.id).toBe('pl-1');
+  });
 });

--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -7,9 +7,12 @@ import { AiService } from '../ai/ai.service';
 import { SpotifyService } from '../spotify/spotify.service';
 import { UsersService } from '../users/users.service';
 import { PreferencesService } from '../preferences/preferences.service';
+import { RedisService } from '../redis/redis.service';
 import { CryptoService } from '../common/crypto/crypto.service';
 import { Emotion } from '../emotions/emotion.entity';
 import { Playlist } from '../playlists/playlist.entity';
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
 
 describe('MusicService', () => {
   let service: MusicService;
@@ -18,6 +21,7 @@ describe('MusicService', () => {
   let spotifyService: { searchTracks: jest.Mock; createPlaylist: jest.Mock };
   let usersService: { findOne: jest.Mock };
   let preferencesService: { findByUserId: jest.Mock };
+  let redisService: { get: jest.Mock; set: jest.Mock };
   let cryptoService: { decrypt: jest.Mock };
 
   const userId = 'user-1';
@@ -77,6 +81,10 @@ describe('MusicService', () => {
     spotifyService = { searchTracks: jest.fn(), createPlaylist: jest.fn() };
     usersService = { findOne: jest.fn().mockResolvedValue(null) };
     preferencesService = { findByUserId: jest.fn().mockResolvedValue(null) };
+    redisService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+    };
     cryptoService = { decrypt: jest.fn((v: string) => `dec(${v})`) };
     playlistRepo.update.mockClear();
 
@@ -94,6 +102,7 @@ describe('MusicService', () => {
         { provide: SpotifyService, useValue: spotifyService },
         { provide: UsersService, useValue: usersService },
         { provide: PreferencesService, useValue: preferencesService },
+        { provide: RedisService, useValue: redisService },
         { provide: CryptoService, useValue: cryptoService },
       ],
     }).compile();
@@ -175,6 +184,7 @@ describe('MusicService', () => {
     });
 
     await service.recommend(userId);
+    await flush();
 
     expect(cryptoService.decrypt).toHaveBeenCalledWith('enc-token');
     expect(spotifyService.createPlaylist).toHaveBeenCalledWith(
@@ -205,7 +215,41 @@ describe('MusicService', () => {
     spotifyService.createPlaylist.mockRejectedValue(new Error('spotify down'));
 
     const result = await service.recommend(userId);
+    await flush();
     expect(result.id).toBe('pl-1');
     expect(playlistRepo.update).not.toHaveBeenCalled();
+  });
+
+  it('caches keyword extraction and skips AI on cache hit', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    spotifyService.searchTracks.mockResolvedValue([track]);
+    redisService.get.mockResolvedValue(
+      JSON.stringify({ keywords: 'cached', title: 'Cached Mix' }),
+    );
+
+    const result = await service.recommend(userId);
+
+    expect(aiService.extractKeywords).not.toHaveBeenCalled();
+    expect(spotifyService.searchTracks).toHaveBeenCalledWith('cached');
+    expect(result.title).toBe('Happy Mix');
+  });
+
+  it('caches keyword result on a cache miss', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    aiService.extractKeywords.mockResolvedValue({
+      keywords: 'fresh',
+      title: 'Fresh Mix',
+    });
+    spotifyService.searchTracks.mockResolvedValue([track]);
+    redisService.get.mockResolvedValue(null);
+
+    await service.recommend(userId);
+
+    expect(aiService.extractKeywords).toHaveBeenCalled();
+    expect(redisService.set).toHaveBeenCalledWith(
+      expect.stringMatching(/^music:kw:/),
+      JSON.stringify({ keywords: 'fresh', title: 'Fresh Mix' }),
+      expect.any(Number),
+    );
   });
 });

--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -227,11 +227,14 @@ describe('MusicService', () => {
       JSON.stringify({ keywords: 'cached', title: 'Cached Mix' }),
     );
 
-    const result = await service.recommend(userId);
+    await service.recommend(userId);
 
     expect(aiService.extractKeywords).not.toHaveBeenCalled();
     expect(spotifyService.searchTracks).toHaveBeenCalledWith('cached');
-    expect(result.title).toBe('Happy Mix');
+    expect(manager.create).toHaveBeenCalledWith(
+      Playlist,
+      expect.objectContaining({ title: 'Cached Mix' }),
+    );
   });
 
   it('caches keyword result on a cache miss', async () => {

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -79,10 +79,11 @@ export class MusicService {
     emotions: EmotionRatios,
     comment: string | null,
   ): string {
-    const sorted = Object.keys(emotions)
+    const safeEmotions = emotions ?? ({} as EmotionRatios);
+    const sorted = Object.keys(safeEmotions)
       .sort()
       .reduce<Record<string, number>>((acc, k) => {
-        acc[k] = emotions[k as keyof EmotionRatios];
+        acc[k] = safeEmotions[k as keyof EmotionRatios];
         return acc;
       }, {});
     const hash = createHash('sha256')

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -1,16 +1,20 @@
+import { createHash } from 'crypto';
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource, In } from 'typeorm';
 import { EmotionsService } from '../emotions/emotions.service';
-import { AiService } from '../ai/ai.service';
+import { AiService, AiKeywordResult, EmotionRatios } from '../ai/ai.service';
 import { SpotifyService, SpotifyTrack } from '../spotify/spotify.service';
 import { UsersService } from '../users/users.service';
 import { PreferencesService } from '../preferences/preferences.service';
+import { RedisService } from '../redis/redis.service';
 import { CryptoService } from '../common/crypto/crypto.service';
 import { Playlist } from '../playlists/playlist.entity';
 import { PlaylistSong } from '../playlists/playlist-song.entity';
 import { Song } from '../songs/song.entity';
 import { PlaylistResDto } from '../playlists/dto/playlist.res.dto';
+
+const KEYWORD_CACHE_TTL = 60 * 60;
 
 @Injectable()
 export class MusicService {
@@ -24,6 +28,7 @@ export class MusicService {
     private readonly spotifyService: SpotifyService,
     private readonly usersService: UsersService,
     private readonly preferencesService: PreferencesService,
+    private readonly redisService: RedisService,
     private readonly cryptoService: CryptoService,
   ) {}
 
@@ -36,7 +41,7 @@ export class MusicService {
     const preference = await this.preferencesService.findByUserId(userId);
     const comment = preference?.data ? JSON.stringify(preference.data) : null;
 
-    const { keywords, title } = await this.aiService.extractKeywords(
+    const { keywords, title } = await this.extractKeywordsCached(
       emotion.emotions,
       comment,
     );
@@ -50,8 +55,27 @@ export class MusicService {
     }
 
     const playlist = await this.save(userId, emotion.emotion, title, tracks);
-    await this.exportToSpotify(userId, playlist, title, tracks);
+    void this.exportToSpotify(userId, playlist, title, tracks);
     return PlaylistResDto.from(playlist);
+  }
+
+  private async extractKeywordsCached(
+    emotions: EmotionRatios,
+    comment: string | null,
+  ): Promise<AiKeywordResult> {
+    const hash = createHash('sha256')
+      .update(JSON.stringify({ emotions, comment }))
+      .digest('hex');
+    const key = `music:kw:${hash}`;
+
+    const cached = await this.redisService.get(key);
+    if (cached) {
+      return JSON.parse(cached) as AiKeywordResult;
+    }
+
+    const result = await this.aiService.extractKeywords(emotions, comment);
+    await this.redisService.set(key, JSON.stringify(result), KEYWORD_CACHE_TTL);
+    return result;
   }
 
   private async exportToSpotify(
@@ -74,8 +98,6 @@ export class MusicService {
         tracks.map((t) => t.id),
       );
 
-      playlist.spotifyPlaylistId = created.id;
-      playlist.spotifyPlaylistUrl = created.url ?? null;
       await this.dataSource.getRepository(Playlist).update(playlist.id, {
         spotifyPlaylistId: created.id,
         spotifyPlaylistUrl: created.url,

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -63,19 +63,59 @@ export class MusicService {
     emotions: EmotionRatios,
     comment: string | null,
   ): Promise<AiKeywordResult> {
-    const hash = createHash('sha256')
-      .update(JSON.stringify({ emotions, comment }))
-      .digest('hex');
-    const key = `music:kw:${hash}`;
+    const key = this.keywordCacheKey(emotions, comment);
 
-    const cached = await this.redisService.get(key);
+    const cached = await this.getCachedKeywords(key);
     if (cached) {
-      return JSON.parse(cached) as AiKeywordResult;
+      return cached;
     }
 
     const result = await this.aiService.extractKeywords(emotions, comment);
-    await this.redisService.set(key, JSON.stringify(result), KEYWORD_CACHE_TTL);
+    await this.setCachedKeywords(key, result);
     return result;
+  }
+
+  private keywordCacheKey(
+    emotions: EmotionRatios,
+    comment: string | null,
+  ): string {
+    const sorted = Object.keys(emotions)
+      .sort()
+      .reduce<Record<string, number>>((acc, k) => {
+        acc[k] = emotions[k as keyof EmotionRatios];
+        return acc;
+      }, {});
+    const hash = createHash('sha256')
+      .update(JSON.stringify({ emotions: sorted, comment }))
+      .digest('hex');
+    return `music:kw:${hash}`;
+  }
+
+  private async getCachedKeywords(
+    key: string,
+  ): Promise<AiKeywordResult | null> {
+    try {
+      const cached = await this.redisService.get(key);
+      return cached ? (JSON.parse(cached) as AiKeywordResult) : null;
+    } catch (error) {
+      this.logger.warn('Keyword cache read failed', error as Error);
+      return null;
+    }
+  }
+
+  private async setCachedKeywords(
+    key: string,
+    result: AiKeywordResult,
+  ): Promise<void> {
+    try {
+      await this.redisService.set(
+        key,
+        JSON.stringify(result),
+        KEYWORD_CACHE_TTL,
+      );
+    } catch (error) {
+      this.logger.warn('Keyword cache write failed', error as Error);
+    }
   }
 
   private async exportToSpotify(

--- a/src/playlists/playlist.entity.ts
+++ b/src/playlists/playlist.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -10,6 +11,7 @@ import {
 import { User } from '../users/user.entity';
 import { PlaylistSong } from './playlist-song.entity';
 
+@Index(['userId', 'createdAt'])
 @Entity('playlists')
 export class Playlist {
   @PrimaryGeneratedColumn('uuid')


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- AI 키워드 추출 결과를 Redis에 캐싱 (감정+취향 해시 키, TTL 1시간) — 동일 조건 반복 추천 시 LLM 호출 스킵 (PER-002)
- Playlist에 (userId, createdAt) 복합 인덱스 추가 — 목록/상세 조회 풀스캔 방지
- Spotify 플레이리스트 생성을 fire-and-forget으로 전환 — 외부 API 왕복을 기다리지 않고 추천 응답을 즉시 반환

## 💬리뷰 요구사항(선택)

> fire-and-forget 전환으로 POST /music 응답의 spotifyPlaylistUrl은 항상 null이 되며, 백그라운드 저장 후 GET /playlists/:id에서 확인됩니다(응답 속도와 즉시성의 트레이드오프). 캐시 키는 감정 비율+취향 JSON의 SHA-256 해시입니다