### PR TITLE
AI 전달 취향을 JSON 대신 평문으로 변환

### DIFF
--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -118,14 +118,14 @@ describe('MusicService', () => {
     });
     spotifyService.searchTracks.mockResolvedValue([track]);
     preferencesService.findByUserId.mockResolvedValue({
-      data: { genre: ['pop'] },
+      data: { genre: ['pop', 'jazz'], bpm: { min: 80, max: 120 } },
     });
 
     const result = await service.recommend(userId);
 
     expect(aiService.extractKeywords).toHaveBeenCalledWith(
       emotion.emotions,
-      JSON.stringify({ genre: ['pop'] }),
+      'genre: pop, jazz, bpm: 80-120',
     );
     expect(result.id).toBe('pl-1');
     expect(result.title).toBe('Happy Mix');

--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -118,14 +118,19 @@ describe('MusicService', () => {
     });
     spotifyService.searchTracks.mockResolvedValue([track]);
     preferencesService.findByUserId.mockResolvedValue({
-      data: { genre: ['pop', 'jazz'], bpm: { min: 80, max: 120 } },
+      data: {
+        genres: ['K-pop', '인디'],
+        favorite_artists: ['아이유'],
+        negative_emotion_response: 'opposite',
+        positive_emotion_response: 'amplify',
+      },
     });
 
     const result = await service.recommend(userId);
 
     expect(aiService.extractKeywords).toHaveBeenCalledWith(
       emotion.emotions,
-      'genre: pop, jazz, bpm: 80-120',
+      '선호 장르: K-pop, 인디, 좋아하는 아티스트: 아이유, 부정적 감정일 때: 반대되는 분위기의 음악 선호, 긍정적 감정일 때: 감정을 증폭하는 음악 선호',
     );
     expect(result.id).toBe('pl-1');
     expect(result.title).toBe('Happy Mix');

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -16,6 +16,23 @@ import { PlaylistResDto } from '../playlists/dto/playlist.res.dto';
 
 const KEYWORD_CACHE_TTL = 60 * 60;
 
+const PREFERENCE_LABELS: Record<string, string> = {
+  genres: '선호 장르',
+  favorite_artists: '좋아하는 아티스트',
+  negative_emotion_response: '부정적 감정일 때',
+  positive_emotion_response: '긍정적 감정일 때',
+};
+
+const EMOTION_RESPONSE_TEXT: Record<string, string> = {
+  opposite: '반대되는 분위기의 음악 선호',
+  amplify: '감정을 증폭하는 음악 선호',
+};
+
+const EMOTION_RESPONSE_KEYS = [
+  'negative_emotion_response',
+  'positive_emotion_response',
+];
+
 @Injectable()
 export class MusicService {
   private readonly logger = new Logger(MusicService.name);
@@ -64,8 +81,12 @@ export class MusicService {
   private toPreferenceText(data: Record<string, unknown>): string | null {
     const parts = Object.entries(data)
       .map(([key, value]) => {
-        const text = this.stringifyValue(value);
-        return text ? `${key}: ${text}` : null;
+        const label = PREFERENCE_LABELS[key] ?? key;
+        const text =
+          EMOTION_RESPONSE_KEYS.includes(key) && typeof value === 'string'
+            ? (EMOTION_RESPONSE_TEXT[value] ?? value)
+            : this.stringifyValue(value);
+        return text ? `${label}: ${text}` : null;
       })
       .filter((part): part is string => part !== null);
     return parts.length > 0 ? parts.join(', ') : null;
@@ -84,7 +105,18 @@ export class MusicService {
     if (typeof value === 'object') {
       const obj = value as Record<string, unknown>;
       if ('min' in obj || 'max' in obj) {
-        return `${this.stringifyValue(obj.min)}-${this.stringifyValue(obj.max)}`;
+        const min =
+          obj.min !== undefined && obj.min !== null
+            ? this.stringifyValue(obj.min)
+            : '';
+        const max =
+          obj.max !== undefined && obj.max !== null
+            ? this.stringifyValue(obj.max)
+            : '';
+        if (min && max) return `${min}-${max}`;
+        if (min) return `>=${min}`;
+        if (max) return `<=${max}`;
+        return '';
       }
       return Object.entries(obj)
         .map(([k, v]) => `${k} ${this.stringifyValue(v)}`.trim())

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -39,7 +39,9 @@ export class MusicService {
     }
 
     const preference = await this.preferencesService.findByUserId(userId);
-    const comment = preference?.data ? JSON.stringify(preference.data) : null;
+    const comment = preference?.data
+      ? this.toPreferenceText(preference.data)
+      : null;
 
     const { keywords, title } = await this.extractKeywordsCached(
       emotion.emotions,
@@ -57,6 +59,45 @@ export class MusicService {
     const playlist = await this.save(userId, emotion.emotion, title, tracks);
     void this.exportToSpotify(userId, playlist, title, tracks);
     return PlaylistResDto.from(playlist);
+  }
+
+  private toPreferenceText(data: Record<string, unknown>): string | null {
+    const parts = Object.entries(data)
+      .map(([key, value]) => {
+        const text = this.stringifyValue(value);
+        return text ? `${key}: ${text}` : null;
+      })
+      .filter((part): part is string => part !== null);
+    return parts.length > 0 ? parts.join(', ') : null;
+  }
+
+  private stringifyValue(value: unknown): string {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    if (Array.isArray(value)) {
+      return value
+        .map((v) => this.stringifyValue(v))
+        .filter(Boolean)
+        .join(', ');
+    }
+    if (typeof value === 'object') {
+      const obj = value as Record<string, unknown>;
+      if ('min' in obj || 'max' in obj) {
+        return `${this.stringifyValue(obj.min)}-${this.stringifyValue(obj.max)}`;
+      }
+      return Object.entries(obj)
+        .map(([k, v]) => `${k} ${this.stringifyValue(v)}`.trim())
+        .filter(Boolean)
+        .join(' ');
+    }
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      return String(value);
+    }
+    return '';
   }
 
   private async extractKeywordsCached(


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- AI 키워드 요청의 comment로 넘기던 사용자 취향을 JSON.stringify 대신 평문으로 변환
- AI 서버가 comment를 프롬프트에 넣어 사용하므로, JSON 형식 대신 자연어 평문이 적합하고 따옴표/파싱 이슈가 사라짐
- 예) {"장르":"발라드","bpm":{"min":80,"max":120}} → "장르: 발라드, bpm: 80-120"

## 💬리뷰 요구사항(선택)

> 취향 data가 자유 JSON 구조라 배열은 콤마, {min,max} 범위는 min-max, 중첩 객체는 키-값 나열로 평문화합니다. 큰따옴표가 포함되지 않아 AI 프롬프트에 안전하게 삽입됩니다