### PR TITLE
AI 키워드 파이프 구분자를 콤마로 변환

### DIFF
--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -138,6 +138,22 @@ describe('MusicService', () => {
     expect(result.tracks[0].duration).toBe('3:20');
   });
 
+  it('converts pipe-separated keywords to comma-separated for search', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    aiService.extractKeywords.mockResolvedValue({
+      keywords: 'calming healing | slow tempo | soft ballad',
+      title: 'Mix',
+    });
+    spotifyService.searchTracks.mockResolvedValue([track]);
+    preferencesService.findByUserId.mockResolvedValue(null);
+
+    await service.recommend(userId);
+
+    expect(spotifyService.searchTracks).toHaveBeenCalledWith(
+      'calming healing, slow tempo, soft ballad',
+    );
+  });
+
   it('sends null comment when the user has no preferences', async () => {
     emotionsService.findTodayLatest.mockResolvedValue(emotion);
     aiService.extractKeywords.mockResolvedValue({ keywords: 'k', title: 'T' });

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -68,7 +68,8 @@ export class MusicService {
       throw new NotFoundException('No music keywords available');
     }
 
-    const tracks = await this.spotifyService.searchTracks(keywords);
+    const query = keywords.replace(/\s*\|\s*/g, ', ');
+    const tracks = await this.spotifyService.searchTracks(query);
     if (tracks.length === 0) {
       throw new NotFoundException('No tracks found');
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

없음

## 📝작업 내용

- AI가 keywords를 파이프(|)로 구분해 여러 검색어 후보를 반환하는데, 이를 Spotify q에 그대로 넣으면 검색이 되지 않던 문제 수정
- 파이프를 콤마로 치환해 하나의 검색 쿼리로 전달 (콤마 구분은 Spotify가 정상 매칭)
- 예) "calming healing | slow tempo | soft ballad" → "calming healing, slow tempo, soft ballad"

## 💬리뷰 요구사항(선택)

> AI 응답 keywords 형식이 파이프 구분으로 바뀌어 대응했습니다. SpotifyService는 콤마를 유지하므로 하나의 q로 검색됩니다