### PR TITLE
fix: 음악 추천 404 발생 시 원인 파악 위한 로그 추가

### DIFF
--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -52,6 +52,9 @@ export class MusicService {
   async recommend(userId: string): Promise<PlaylistResDto> {
     const emotion = await this.emotionsService.findTodayLatest(userId);
     if (!emotion) {
+      this.logger.warn(
+        `Reject recommend: no emotion analysis today for user ${userId}`,
+      );
       throw new NotFoundException('No emotion analysis found for today');
     }
 
@@ -65,12 +68,18 @@ export class MusicService {
       comment,
     );
     if (!keywords?.trim()) {
+      this.logger.warn(
+        `Reject recommend: no keywords from AI for user ${userId}`,
+      );
       throw new NotFoundException('No music keywords available');
     }
 
     const query = keywords.replace(/\s*\|\s*/g, ', ');
     const tracks = await this.spotifyService.searchTracks(query);
     if (tracks.length === 0) {
+      this.logger.warn(
+        `Reject recommend: no tracks found for query "${query}" (user ${userId})`,
+      );
       throw new NotFoundException('No tracks found');
     }
 


### PR DESCRIPTION
## Summary
- 음악 추천(`POST /music`)에서 404가 날 때 어느 조건에서 발생했는지 로그로 확인할 수 있도록 3가지 NotFoundException 케이스에 warn 로그 추가
  - 오늘자 감정 분석 없음
  - AI 키워드 추출 결과 없음
  - Spotify 검색 결과 없음

## Test plan
- [x] `npx jest src/music/music.service.spec.ts` 통과
- [x] `npx eslint src/music/music.service.ts` 통과