### PR TITLE
fix: Spotify 검색 쿼리에서 AI 감정 신뢰도 괄호 표기 제거

### DIFF
--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -154,6 +154,22 @@ describe('MusicService', () => {
     );
   });
 
+  it('strips parenthetical confidence annotations from the search query', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    aiService.extractKeywords.mockResolvedValue({
+      keywords: 'uplifting bright (happy 0.86) | energetic fast (happy 0.86)',
+      title: 'Mix',
+    });
+    spotifyService.searchTracks.mockResolvedValue([track]);
+    preferencesService.findByUserId.mockResolvedValue(null);
+
+    await service.recommend(userId);
+
+    expect(spotifyService.searchTracks).toHaveBeenCalledWith(
+      'uplifting bright, energetic fast',
+    );
+  });
+
   it('sends null comment when the user has no preferences', async () => {
     emotionsService.findTodayLatest.mockResolvedValue(emotion);
     aiService.extractKeywords.mockResolvedValue({ keywords: 'k', title: 'T' });

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -74,7 +74,11 @@ export class MusicService {
       throw new NotFoundException('No music keywords available');
     }
 
-    const query = keywords.replace(/\s*\|\s*/g, ', ');
+    const query = keywords
+      .replace(/\([^)]*\)/g, '')
+      .replace(/\s*\|\s*/g, ', ')
+      .replace(/\s+/g, ' ')
+      .trim();
     const tracks = await this.spotifyService.searchTracks(query);
     if (tracks.length === 0) {
       this.logger.warn(


### PR DESCRIPTION
## Summary
- 실서버 로그에서 `/music` 404("No tracks found") 확인, AI가 준 키워드에 `(happy 0.86)` 같은 감정 신뢰도 표기가 그대로 섞여 있어 Spotify 검색어 노이즈로 작용하던 문제
- `music.service.ts`의 쿼리 생성 시 괄호 안 내용을 제거하고 공백을 정리하도록 수정

## Test plan
- [x] `npx jest src/music/music.service.spec.ts` 통과 (신규 케이스 포함)
- [x] `npx eslint` 통과