### PR TITLE
fix: Spotify 검색 결과 없으면 첫 키워드 구문으로 재검색

### DIFF
--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -73,7 +73,10 @@ describe('MusicService', () => {
     findOneOrFail: jest.fn().mockResolvedValue(savedPlaylist),
   };
 
-  const playlistRepo = { update: jest.fn().mockResolvedValue(undefined) };
+  const playlistRepo = {
+    update: jest.fn().mockResolvedValue(undefined),
+    findOne: jest.fn().mockResolvedValue(null),
+  };
 
   beforeEach(async () => {
     emotionsService = { findTodayLatest: jest.fn() };
@@ -87,6 +90,8 @@ describe('MusicService', () => {
     };
     cryptoService = { decrypt: jest.fn((v: string) => `dec(${v})`) };
     playlistRepo.update.mockClear();
+    playlistRepo.findOne.mockClear();
+    playlistRepo.findOne.mockResolvedValue(null);
 
     const dataSource = {
       transaction: jest.fn((cb: (m: typeof manager) => unknown) => cb(manager)),
@@ -214,7 +219,7 @@ describe('MusicService', () => {
     );
   });
 
-  it('throws NotFoundException when spotify returns no tracks', async () => {
+  it('throws NotFoundException when spotify returns no tracks and no previous playlist exists', async () => {
     emotionsService.findTodayLatest.mockResolvedValue(emotion);
     aiService.extractKeywords.mockResolvedValue({
       keywords: 'happy',
@@ -225,6 +230,23 @@ describe('MusicService', () => {
     await expect(service.recommend(userId)).rejects.toBeInstanceOf(
       NotFoundException,
     );
+  });
+
+  it('falls back to the previous playlist when spotify returns no tracks', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    aiService.extractKeywords.mockResolvedValue({
+      keywords: 'happy',
+      title: 'Mix',
+    });
+    spotifyService.searchTracks.mockResolvedValue([]);
+    playlistRepo.findOne.mockResolvedValue(savedPlaylist);
+
+    const result = await service.recommend(userId);
+
+    expect(playlistRepo.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId } }),
+    );
+    expect(result.id).toBe('pl-1');
   });
 
   it('exports to Spotify when the user has a refresh token', async () => {

--- a/src/music/music.service.spec.ts
+++ b/src/music/music.service.spec.ts
@@ -170,6 +170,29 @@ describe('MusicService', () => {
     );
   });
 
+  it('falls back to the first keyword segment when the full query has no matches', async () => {
+    emotionsService.findTodayLatest.mockResolvedValue(emotion);
+    aiService.extractKeywords.mockResolvedValue({
+      keywords: 'uplifting bright | energetic fast | obscure long tail phrase',
+      title: 'Mix',
+    });
+    spotifyService.searchTracks
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([track]);
+    preferencesService.findByUserId.mockResolvedValue(null);
+
+    await service.recommend(userId);
+
+    expect(spotifyService.searchTracks).toHaveBeenNthCalledWith(
+      1,
+      'uplifting bright, energetic fast, obscure long tail phrase',
+    );
+    expect(spotifyService.searchTracks).toHaveBeenNthCalledWith(
+      2,
+      'uplifting bright',
+    );
+  });
+
   it('sends null comment when the user has no preferences', async () => {
     emotionsService.findTodayLatest.mockResolvedValue(emotion);
     aiService.extractKeywords.mockResolvedValue({ keywords: 'k', title: 'T' });

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -74,12 +74,22 @@ export class MusicService {
       throw new NotFoundException('No music keywords available');
     }
 
-    const query = keywords
-      .replace(/\([^)]*\)/g, '')
-      .replace(/\s*\|\s*/g, ', ')
-      .replace(/\s+/g, ' ')
-      .trim();
-    const tracks = await this.spotifyService.searchTracks(query);
+    const segments = keywords
+      .split('|')
+      .map((s) =>
+        s
+          .replace(/\([^)]*\)/g, '')
+          .replace(/\s+/g, ' ')
+          .trim(),
+      )
+      .filter(Boolean);
+
+    let query = segments.join(', ');
+    let tracks = await this.spotifyService.searchTracks(query);
+    if (tracks.length === 0 && segments.length > 1) {
+      query = segments[0];
+      tracks = await this.spotifyService.searchTracks(query);
+    }
     if (tracks.length === 0) {
       this.logger.warn(
         `Reject recommend: no tracks found for query "${query}" (user ${userId})`,

--- a/src/music/music.service.ts
+++ b/src/music/music.service.ts
@@ -94,12 +94,27 @@ export class MusicService {
       this.logger.warn(
         `Reject recommend: no tracks found for query "${query}" (user ${userId})`,
       );
+      const previous = await this.findLatestPlaylist(userId);
+      if (previous) {
+        this.logger.warn(
+          `Fallback recommend: returning previous playlist for user ${userId}`,
+        );
+        return PlaylistResDto.from(previous);
+      }
       throw new NotFoundException('No tracks found');
     }
 
     const playlist = await this.save(userId, emotion.emotion, title, tracks);
     void this.exportToSpotify(userId, playlist, title, tracks);
     return PlaylistResDto.from(playlist);
+  }
+
+  private findLatestPlaylist(userId: string): Promise<Playlist | null> {
+    return this.dataSource.getRepository(Playlist).findOne({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+      relations: ['playlistSongs', 'playlistSongs.song'],
+    });
   }
 
   private toPreferenceText(data: Record<string, unknown>): string | null {


### PR DESCRIPTION
## Summary
- 이전 괄호 제거 수정 이후에도 실서버에서 동일 유저에게 계속 404("No tracks found") 발생 확인
- 원인 검증: 컨테이너에서 직접 Spotify 검색 API 호출해보니 짧은 키워드 하나("uplifting energetic bright")는 매번 결과가 나오는데, 4개 구문을 콤마로 이어붙인 긴 쿼리는 재현 가능하게 0건 반환
- AI가 주는 키워드 구문이 여러 개로 늘어나면 Spotify 자유 텍스트 검색이 매칭에 실패하는 경우가 있어서:
  1. 전체 쿼리로 검색해 0건이면 가장 첫 번째(가장 간결한) 키워드 구문으로 한 번 더 검색
  2. 그래도 0건이면 클라이언트에 404를 주는 대신 유저의 가장 최근 플레이리스트를 그대로 반환 (신규 추천 실패 시 에러 대신 기존 결과로 폴백)

## Test plan
- [x] `npx jest src/music/music.service.spec.ts` 통과 (신규 케이스 포함, 13개)
- [x] `npx eslint` 통과
- [x] 실서버 컨테이너에서 Spotify API 직접 호출로 원인 재현 확인